### PR TITLE
Add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Normalize line endings on text files
+*.java   text
+*.sh     text
+*.yml    text
+*.md     text
+*.gradle text


### PR DESCRIPTION
We want Windows devs to be able to contribute without having to worry
about keeping CRLF out of source files.

See: http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/
