### PR TITLE
Fixed a bug when inserting a graph from an expression in CPOG plugin

### DIFF
--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/CpogSelectionTool.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/CpogSelectionTool.java
@@ -326,10 +326,10 @@ public class CpogSelectionTool extends SelectionTool {
         text = text.replace("\n", "");
         text = parsingTool.replaceReferences(text);
 
-        if (text.contains(" = ")) {
-            name = text.substring(0, text.indexOf(" = "));
+        if (text.contains("=")) {
+            name = text.substring(0, text.indexOf("="));
             name = name.trim();
-            text = text.substring(text.indexOf(" = ") + 1);
+            text = text.substring(text.indexOf("=") + 1);
             text = text.trim();
         }
 


### PR DESCRIPTION
Found a bug where inserting a CPOG from an expression with a graph name eg.

`A = b -> c -> d` 

would caused a parsing exception to be thrown and no graph to be inserted.
