### PR TITLE
Pass PComp results via temporary file

### DIFF
--- a/CircuitPlugin/src/org/workcraft/plugins/circuit/stg/CircuitStgUtils.java
+++ b/CircuitPlugin/src/org/workcraft/plugins/circuit/stg/CircuitStgUtils.java
@@ -59,11 +59,11 @@ public class CircuitStgUtils {
             // Generating .g for the whole system (circuit and environment)
             File sysStgFile = new File(directory, StgUtils.SYSTEM_FILE_NAME + StgUtils.ASTG_FILE_EXT);
             sysStgFile.deleteOnExit();
-            Result<? extends ExternalProcessResult> pcompResult = composeDevWithEnv(devStgFile, envStgFile, directory, null);
+            Result<? extends ExternalProcessResult> pcompResult = composeDevWithEnv(devStgFile, envStgFile, sysStgFile,
+                    null, directory, null);
 
             switch (pcompResult.getOutcome()) {
             case FINISHED:
-                FileUtils.writeAllText(sysStgFile, new String(pcompResult.getReturnValue().getOutput()));
                 break;
             case CANCELLED:
                 sysStgFile = null;
@@ -132,11 +132,11 @@ public class CircuitStgUtils {
         return framework.getTaskManager().execute(exportTask, description, subtaskMonitor);
     }
 
-    public static Result<? extends ExternalProcessResult> composeDevWithEnv(File devStgFile, File envStgFile, File directory,
-            ProgressMonitor<? super MpsatChainResult> monitor) {
+    public static Result<? extends ExternalProcessResult> composeDevWithEnv(File devStgFile, File envStgFile, File sysStgFile,
+            File placesFile, File directory, ProgressMonitor<? super MpsatChainResult> monitor) {
         Framework framework = Framework.getInstance();
         File[] inputFiles = new File[]{devStgFile, envStgFile};
-        PcompTask pcompTask = new PcompTask(inputFiles, ConversionMode.OUTPUT, true, false, directory);
+        PcompTask pcompTask = new PcompTask(inputFiles, sysStgFile, placesFile, ConversionMode.OUTPUT, true, false, directory);
         String description = "Running parallel composition [PComp]";
         SubtaskMonitor<Object> subtaskMonitor = null;
         if (monitor != null) {

--- a/MpsatVerificationPlugin/src/org/workcraft/plugins/mpsat/MpsatCscResolutionResultHandler.java
+++ b/MpsatVerificationPlugin/src/org/workcraft/plugins/mpsat/MpsatCscResolutionResultHandler.java
@@ -8,6 +8,7 @@ import javax.swing.JOptionPane;
 import org.workcraft.Framework;
 import org.workcraft.exceptions.DeserialisationException;
 import org.workcraft.gui.workspace.Path;
+import org.workcraft.plugins.mpsat.tasks.MpsatTask;
 import org.workcraft.plugins.shared.CommonEditorSettings;
 import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
 import org.workcraft.plugins.stg.STGModel;
@@ -30,7 +31,7 @@ public class MpsatCscResolutionResultHandler implements Runnable {
     }
 
     public STGModel getResolvedStg() {
-        final byte[] output = result.getReturnValue().getOutputFile("mpsat.g");
+        final byte[] output = result.getReturnValue().getOutputFile(MpsatTask.FILE_MPSAT_G);
         if (output == null) {
             return null;
         }

--- a/MpsatVerificationPlugin/src/org/workcraft/plugins/mpsat/tasks/MpsatTask.java
+++ b/MpsatVerificationPlugin/src/org/workcraft/plugins/mpsat/tasks/MpsatTask.java
@@ -22,6 +22,8 @@ import org.workcraft.util.FileUtils;
 import org.workcraft.util.ToolUtils;
 
 public class MpsatTask implements Task<ExternalProcessResult> {
+    public static final String FILE_MPSAT_G = "mpsat.g";
+
     private final String[] args;
     private final String inputFileName;
     private final File directory;
@@ -81,9 +83,9 @@ public class MpsatTask implements Task<ExternalProcessResult> {
 
         Map<String, byte[]> outputFiles = new HashMap<String, byte[]>();
         try {
-            File g = new File(directory, "mpsat.g");
-            if (g.exists()) {
-                outputFiles.put("mpsat.g", FileUtils.readAllBytes(g));
+            File outFile = new File(directory, FILE_MPSAT_G);
+            if (outFile.exists()) {
+                outputFiles.put(FILE_MPSAT_G, FileUtils.readAllBytes(outFile));
             }
         } catch (IOException e) {
             return new Result<ExternalProcessResult>(e);

--- a/PcompPlugin/src/org/workcraft/plugins/pcomp/tools/PcompTool.java
+++ b/PcompPlugin/src/org/workcraft/plugins/pcomp/tools/PcompTool.java
@@ -48,16 +48,20 @@ public class PcompTool implements Tool {
         if (dialog.run()) {
             String tmpPrefix = FileUtils.getTempPrefix("pcomp");
             File tmpDirectory = FileUtils.createTempDirectory(tmpPrefix);
-            ArrayList<File> inputs = new ArrayList<File>();
+            ArrayList<File> inputFiles = new ArrayList<File>();
             for (Path<String> path : dialog.getSourcePaths()) {
                 Workspace workspace = framework.getWorkspace();
                 File stgFile = exportStg(workspace.getOpenFile(path), tmpDirectory);
-                inputs.add(stgFile);
+                inputFiles.add(stgFile);
             }
-            PcompTask pcompTask = new PcompTask(inputs.toArray(new File[0]), dialog.getMode(),
-                    dialog.isSharedOutputsChecked(), dialog.isImprovedPcompChecked(), tmpDirectory);
 
-            PcompResultHandler pcompResult = new PcompResultHandler(dialog.showInEditor(), tmpDirectory);
+            File outputFile = new File(tmpDirectory, "result.g");
+            outputFile.deleteOnExit();
+
+            PcompTask pcompTask = new PcompTask(inputFiles.toArray(new File[0]), outputFile, null,
+                    dialog.getMode(), dialog.isSharedOutputsChecked(), dialog.isImprovedPcompChecked(), tmpDirectory);
+
+            PcompResultHandler pcompResult = new PcompResultHandler(dialog.showInEditor(), outputFile);
             framework.getTaskManager().queue(pcompTask, "Running parallel composition [PComp]", pcompResult);
         }
     }

--- a/STGPlugin/src/org/workcraft/plugins/stg/StgUtils.java
+++ b/STGPlugin/src/org/workcraft/plugins/stg/StgUtils.java
@@ -13,6 +13,8 @@ public class StgUtils {
     public static final String SYSTEM_FILE_NAME = "system";
     public static final String MODIFIED_FILE_SUFFIX = "_mod";
     public static final String ASTG_FILE_EXT = ".g";
+    public static final String PLACES_FILE_NAME = "places";
+    public static final String LIST_FILE_EXT = ".list";
 
     private static void replaceNamedTransition(STG stg, NamedTransition oldTransition, NamedTransition newTransition) {
         for (Node pred: stg.getPreset(oldTransition)) {


### PR DESCRIPTION
Note this requires PComp from UnfoldingTools v1.02 or newer.

Closes #374.
