### PR TITLE
Synchronise stdout with the process termination

### DIFF
--- a/MpsatVerificationPlugin/src/org/workcraft/plugins/mpsat/tasks/MpsatTask.java
+++ b/MpsatVerificationPlugin/src/org/workcraft/plugins/mpsat/tasks/MpsatTask.java
@@ -75,7 +75,7 @@ public class MpsatTask implements Task<ExternalProcessResult> {
 
         boolean printStdout = MpsatUtilitySettings.getPrintStdout();
         boolean printStderr = MpsatUtilitySettings.getPrintStderr();
-        ExternalProcessTask task = new ExternalProcessTask(command, directory, printStdout, printStderr);
+        ExternalProcessTask task = new ExternalProcessTask(command, directory, printStdout, printStderr, 500);
         Result<? extends ExternalProcessResult> res = task.run(monitor);
         if (res.getOutcome() == Outcome.CANCELLED) {
             return res;

--- a/PunfPlugin/src/org/workcraft/plugins/punf/tasks/PunfTask.java
+++ b/PunfPlugin/src/org/workcraft/plugins/punf/tasks/PunfTask.java
@@ -41,7 +41,7 @@ public class PunfTask implements Task<ExternalProcessResult> {
 
         boolean printStdout = PunfUtilitySettings.getPrintStdout();
         boolean printStderr = PunfUtilitySettings.getPrintStderr();
-        ExternalProcessTask task = new ExternalProcessTask(command, null, printStdout, printStderr);
+        ExternalProcessTask task = new ExternalProcessTask(command, null, printStdout, printStderr, 500);
         Result<? extends ExternalProcessResult> res = task.run(monitor);
 
         if (res.getOutcome() != Outcome.FINISHED) {

--- a/WorkcraftCore/src/org/workcraft/gui/DesktopApi.java
+++ b/WorkcraftCore/src/org/workcraft/gui/DesktopApi.java
@@ -22,14 +22,14 @@ public class DesktopApi {
     }
 
     public static boolean open(File file) {
-        if (openSystemSpecific(file.getPath())) return true;
         if (openDesktop(file)) return true;
+        if (openSystemSpecific(file.getPath())) return true;
         return false;
     }
 
     public static boolean edit(File file) {
-        if (openSystemSpecific(file.getPath())) return true;
         if (editDesktop(file)) return true;
+        if (openSystemSpecific(file.getPath())) return true;
         return false;
     }
 
@@ -73,9 +73,9 @@ public class DesktopApi {
         OsType os = getOs();
 
         if (os.isLinux()) {
+            if (runCommand("xdg-open", "%s", what)) return true;
             if (runCommand("kde-open", "%s", what)) return true;
             if (runCommand("gnome-open", "%s", what)) return true;
-            if (runCommand("xdg-open", "%s", what)) return true;
         }
 
         if (os.isMac()) {

--- a/WorkcraftCore/src/org/workcraft/plugins/shared/tasks/ExternalProcessTask.java
+++ b/WorkcraftCore/src/org/workcraft/plugins/shared/tasks/ExternalProcessTask.java
@@ -18,6 +18,7 @@ public class ExternalProcessTask implements Task<ExternalProcessResult>, Externa
     private final File workingDir;
     private boolean printStdout;
     private boolean printStderr;
+    private int delayOnFinish;
 
     private volatile boolean finished;
     private volatile int returnCode;
@@ -28,14 +29,19 @@ public class ExternalProcessTask implements Task<ExternalProcessResult>, Externa
     private DataAccumulator stderrAccum = new DataAccumulator();
 
     public ExternalProcessTask(List<String> args, File workingDir) {
-        this(args, workingDir, false, false);
+        this(args, workingDir, false, false, 0);
     }
 
     public ExternalProcessTask(List<String> args, File workingDir, boolean printStdout, boolean printStderr) {
+        this(args, workingDir, printStdout, printStderr, 0);
+    }
+
+    public ExternalProcessTask(List<String> args, File workingDir, boolean printStdout, boolean printStderr, int delayOnFinish) {
         this.args = args;
         this.workingDir = workingDir;
         this.printStdout = printStdout;
         this.printStderr = printStderr;
+        this.delayOnFinish = delayOnFinish;
     }
 
     @Override
@@ -74,17 +80,17 @@ public class ExternalProcessTask implements Task<ExternalProcessResult>, Externa
             return Result.cancelled();
         }
 
-        // FIXME: An attempt to synchronise the output streams with the process completion.
-//        try {
-//            process.closeInput();
-//        } catch (IOException e) {
-//        }
-//
-//        try {
-//            Thread.sleep(delayOnFinish);
-//        } catch(InterruptedException ex) {
-//            Thread.currentThread().interrupt();
-//        }
+        // FIXME: An attempt to synchronize the output streams with the process completion.
+        try {
+            process.closeInput();
+        } catch (IOException e) {
+        }
+
+        try {
+            Thread.sleep(delayOnFinish);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
 
         ExternalProcessResult result = new ExternalProcessResult(
                 returnCode, stdoutAccum.getData(), stderrAccum.getData(),


### PR DESCRIPTION
A temporary workaround by delaying processing of results
for MPSat and Punf tools (the ones that pass data via stdout).
