### PR TITLE
gradle: check for code duplication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'ca.coglinc:javacc-gradle-plugin:2.3.1'
+        classpath 'de.aaschmid.gradle.plugins:gradle-cpd-plugin:0.5'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
     }
 }
@@ -15,6 +16,7 @@ subprojects {
 
     apply plugin: 'java'
     apply plugin: 'ca.coglinc.javacc'
+    apply plugin: 'cpd'
     apply plugin: 'jacoco'
     apply plugin: 'com.github.kt3k.coveralls'
 
@@ -66,6 +68,20 @@ subprojects {
         configFile file("${project.rootDir}/config/checkstyle/checkstyle.xml")
     }
     checkstyleMain.exclude '**/jj/**'
+
+    cpd {
+        toolVersion = '5.4.1'
+        minimumTokenCount = 2000
+    }
+
+    cpdCheck {
+        reports {
+            text.enabled = true
+            xml.enabled = false
+        }
+        source = sourceSets.main.allJava
+    }
+    cpdCheck.exclude '**/jj/**'
 
     jacocoTestReport {
         reports {


### PR DESCRIPTION
Right now only 2000 tokens or more are considered too much. This is of
course way too high. It should be lowered with time, fixing the errors.
Lowering to 500 or even 1000 already shows errors.

Fixes #389.
