### PR TITLE
Changed inserting CPOGs from files allowing inserting results from PGminer

### DIFF
--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tasks/PGMinerResultHandler.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tasks/PGMinerResultHandler.java
@@ -31,11 +31,13 @@ public class PGMinerResultHandler extends DummyProgressMonitor<ExternalProcessRe
     private VisualCPOG visualCpog;
     private WorkspaceEntry we;
     private boolean createNewWindow;
+    private File outputFile;
 
-    public PGMinerResultHandler(VisualCPOG visualCpog, WorkspaceEntry we, boolean createNewWindow) {
+    public PGMinerResultHandler(VisualCPOG visualCpog, WorkspaceEntry we, boolean createNewWindow, File outputFile) {
         this.visualCpog = visualCpog;
         this.we = we;
         this.createNewWindow = createNewWindow;
+        this.outputFile = outputFile;
     }
 
     public void finished(final Result<? extends ExternalProcessResult> result, String description) {
@@ -71,15 +73,16 @@ public class PGMinerResultHandler extends DummyProgressMonitor<ExternalProcessRe
                                 e.printStackTrace();
                             }
                         }
+
                         we.captureMemento();
-                        byte[] output = result.getReturnValue().getOutputFile("output.cpog");
-                        String text = new String(output);
-                        String[] line = text.split("\r\n");
-                        tool.getLowestVertex(visualCpog);
-                        for (int i = 0; i < line.length; i++) {
-                            tool.insertExpression(line[i], visualCpog, false, false, false, true);
+
+
+                        if (tool.insertCpogFromFile(outputFile)) {
+                            we.saveMemento();
+                        } else {
+                            we.cancelMemento();
                         }
-                        we.saveMemento();
+
                     }
                 }
             });

--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tasks/PGMinerTask.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tasks/PGMinerTask.java
@@ -76,6 +76,7 @@ public class PGMinerTask implements Task<ExternalProcessResult> {
 
     public File getOutputFile(File inputFile) {
 
+
         String filePath = inputFile.getAbsolutePath();
 
         int index = filePath.lastIndexOf('/');
@@ -87,5 +88,6 @@ public class PGMinerTask implements Task<ExternalProcessResult> {
 
         return outputFile;
     }
+
 
 }

--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/CpogSelectionTool.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/CpogSelectionTool.java
@@ -175,77 +175,31 @@ public class CpogSelectionTool extends SelectionTool {
         });
         buttonPanel.add(btnInsert);
 
-        final JButton btnTextInsert = new JButton("Text File");
-        btnTextInsert.addActionListener(new ActionListener() {
+        final JButton btnFileInsert = new JButton("Text File");
+        btnFileInsert.addActionListener(new ActionListener() {
 
             @Override
             public void actionPerformed(ActionEvent e) {
                 editor.getWorkspaceEntry().captureMemento();
                 JFileChooser chooser = new JFileChooser();
                 File textFile;
-                Scanner fileIn = null;
-                String equation;
-
                 FileNameExtensionFilter filter = new FileNameExtensionFilter(
                         "Text Files", "txt");
                 chooser.setFileFilter(filter);
                 if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
-                    ArrayList<String> expressions = new ArrayList<>();
 
                     textFile = chooser.getSelectedFile();
-                    try {
-                        fileIn = new Scanner(textFile);
-                    } catch (FileNotFoundException e1) {
-                        // TODO Auto-generated catch block
-                        JOptionPane.showMessageDialog(null, e1.getMessage(),
-                                "File not found error", JOptionPane.ERROR_MESSAGE);
-                    }
-                    WorkspaceEntry we = editor.getWorkspaceEntry();
-                    VisualCPOG visualCpog = (VisualCPOG) we.getModelEntry().getVisualModel();
-                    coordinate = getLowestVertex(visualCpog);
-                    coordinate.setLocation(coordinate.getX(), coordinate.getY() + 2);
-                    String expression = "";
-                    int lineCount = 0;
-                    int prevLineEnd = 0;
-                    while (fileIn.hasNextLine()) {
-                        expression = expression + fileIn.nextLine() + "\n";
-                        lineCount++;
+
+                    if (insertCpogFromFile(textFile)) {
+                        editor.getWorkspaceEntry().saveMemento();
+                    } else {
+                        editor.getWorkspaceEntry().cancelMemento();
                     }
 
-                    for (int i = 0; i < lineCount; i++) {
-                        String exp = expression.substring(prevLineEnd, expression.indexOf("\n") + 1);
-
-                        exp = exp.replace("\n", "");
-                        exp = exp.replace("\t", " ");
-
-                        if (exp.compareTo("") != 0) {
-                            expressions.add(exp);
-                        }
-
-                        expression = expression.substring(expression.indexOf("\n") + 1);
-                    }
-                    String exp = "";
-                    coordinate = getLowestVertex(visualCpog);
-                    coordinate.setLocation(coordinate.getX(), coordinate.getY() + 2);
-                    for (String s : expressions) {
-                        if (!s.contains("=")) {
-                            exp = exp + " " + s;
-                        } else {
-                            if (exp.compareTo("") != 0) {
-                                insertExpression(exp, visualCpog, false, false, true, false);
-                                exp = "";
-                            }
-                            exp = s;
-                        }
-                    }
-                    if (exp.compareTo("") != 0) {
-                        insertExpression(exp, visualCpog, false, false, true, false);
-                    }
-                    editor.getWorkspaceEntry().saveMemento();
                 }
             }
         });
-        buttonPanel.add(btnTextInsert);
+        buttonPanel.add(btnFileInsert);
 
         final JButton btnGetGraphExpression = new JButton("Get expression");
         btnGetGraphExpression.addActionListener(new ActionListener() {
@@ -1150,6 +1104,57 @@ public class CpogSelectionTool extends SelectionTool {
         }
 
         new RenderTypeChangedHandler().attach(visualCpog.getRoot());
+
+    }
+
+    public boolean insertCpogFromFile(File f) {
+        Scanner fileIn;
+        String[] expressions;
+        try {
+            fileIn = new Scanner(f);
+        } catch (FileNotFoundException e1) {
+            // TODO Auto-generated catch block
+            JOptionPane.showMessageDialog(null, e1.getMessage(),
+                    "File not found error", JOptionPane.ERROR_MESSAGE);
+            return false;
+        }
+
+        WorkspaceEntry we = editor.getWorkspaceEntry();
+        VisualCPOG visualCpog = (VisualCPOG) we.getModelEntry().getVisualModel();
+
+        coordinate = getLowestVertex(visualCpog);
+        coordinate.setLocation(coordinate.getX(), coordinate.getY() + 2);
+
+        String expression = "";
+
+        while (fileIn.hasNextLine()) {
+            expression = expression + fileIn.nextLine() + "\n";
+        }
+        fileIn.close();
+
+        expressions = expression.split("\n");
+
+        String exp = "";
+        coordinate = getLowestVertex(visualCpog);
+        coordinate.setLocation(coordinate.getX(), coordinate.getY() + 2);
+
+        for (String s : expressions) {
+            if (!s.contains("=")) {
+                exp = exp + " " + s;
+            } else {
+                if (exp.compareTo("") != 0) {
+                    insertExpression(exp, visualCpog, false, false, true, false);
+                    exp = "";
+                }
+                exp = s;
+            }
+        }
+        if (exp.compareTo("") != 0) {
+            insertExpression(exp, visualCpog, false, false, true, false);
+        }
+
+        return true;
+
 
     }
 }

--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerImportTool.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerImportTool.java
@@ -125,7 +125,7 @@ public class PGMinerImportTool implements Tool {
                 if (dialog.getExtractConcurrency()) {
                     PGMinerTask task = new PGMinerTask(inputFile, dialog.getSplit());
 
-                    PGMinerResultHandler result = new PGMinerResultHandler((VisualCPOG) we.getModelEntry().getVisualModel(), we, false);
+                    PGMinerResultHandler result = new PGMinerResultHandler((VisualCPOG) we.getModelEntry().getVisualModel(), we, false, task.getOutputFile(inputFile));
                     framework.getTaskManager().queue(task, "PGMiner", result);
                 } else {
                     Scanner k;
@@ -146,6 +146,7 @@ public class PGMinerImportTool implements Tool {
                 }
             }
         } catch (Exception e) {
+            e.printStackTrace();
             editor.getWorkspaceEntry().cancelMemento();
         }
     }

--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerSelectedGraphsExtractionTool.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerSelectedGraphsExtractionTool.java
@@ -98,7 +98,7 @@ public class PGMinerSelectedGraphsExtractionTool implements Tool {
             PGMinerTask task = new PGMinerTask(inputFile, false);
 
             final Framework framework = Framework.getInstance();
-            PGMinerResultHandler result = new PGMinerResultHandler((VisualCPOG) we.getModelEntry().getVisualModel(), we, true);
+            PGMinerResultHandler result = new PGMinerResultHandler((VisualCPOG) we.getModelEntry().getVisualModel(), we, true, task.getOutputFile(inputFile));
             framework.getTaskManager().queue(task, "PGMiner", result);
         } catch (ArrayIndexOutOfBoundsException e) {
 

--- a/PetrifyExtraPlugin/src/org/workcraft/plugins/petrify/PetrifyExtraModule.java
+++ b/PetrifyExtraPlugin/src/org/workcraft/plugins/petrify/PetrifyExtraModule.java
@@ -15,7 +15,7 @@ public class PetrifyExtraModule implements Module {
     public void init() {
         final Framework framework = Framework.getInstance();
         PluginManager pm = framework.getPluginManager();
-        pm.registerClass(Exporter.class, PSExporter.class);
+        pm.registerClass(Exporter.class, AstgExporter.class);
         pm.registerClass(Settings.class, PetrifyExtraUtilitySettings.class);
 
         pm.registerClass(Tool.class, new Initialiser<Tool>() {

--- a/PetrifyExtraPlugin/src/org/workcraft/plugins/petrify/tasks/DrawSgResult.java
+++ b/PetrifyExtraPlugin/src/org/workcraft/plugins/petrify/tasks/DrawSgResult.java
@@ -3,16 +3,16 @@ package org.workcraft.plugins.petrify.tasks;
 import java.io.File;
 
 public class DrawSgResult {
-    private File psFile = null;
+    private File file = null;
     private String errorMessages = null;
 
-    public DrawSgResult(File psFile, String errorMessages) {
-        this.psFile = psFile;
+    public DrawSgResult(File file, String errorMessages) {
+        this.file = file;
         this.errorMessages = errorMessages;
     }
 
-    public File getPsFile() {
-        return psFile;
+    public File getFile() {
+        return file;
     }
 
     public String getErrorMessages() {

--- a/PetrifyExtraPlugin/src/org/workcraft/plugins/petrify/tools/ShowSg.java
+++ b/PetrifyExtraPlugin/src/org/workcraft/plugins/petrify/tools/ShowSg.java
@@ -63,8 +63,7 @@ public class ShowSg implements Tool {
             @Override
             public void finished(Result<? extends DrawSgResult> result, String description) {
                 if (result.getOutcome() == Outcome.FINISHED) {
-                    DesktopApi.open(result.getReturnValue().getPsFile());
-                    //SystemOpen.open(result.getReturnValue().getPsFile());
+                    DesktopApi.open(result.getReturnValue().getFile());
                 } else  if (result.getOutcome() != Outcome.CANCELLED) {
                     String errorMessage = "Petrify tool chain execution failed :-(";
                     Throwable cause = result.getCause();

--- a/WorkcraftCore/src/org/workcraft/util/FileUtils.java
+++ b/WorkcraftCore/src/org/workcraft/util/FileUtils.java
@@ -86,10 +86,10 @@ public class FileUtils {
         if ((title != null) && !title.isEmpty()) {
             prefix = TEMP_DIRECTORY_PREFIX + title + "-";
         }
-        return getGoodTempPrefix(prefix);
+        return getCorrectTempPrefix(prefix);
     }
 
-    public static String getGoodTempPrefix(String prefix) {
+    private static String getCorrectTempPrefix(String prefix) {
         if (prefix == null) {
             prefix = "";
         }
@@ -109,7 +109,7 @@ public class FileUtils {
 
     public static File createTempFile(String prefix, String suffix, File directory) {
         File tempFile = null;
-        prefix = getGoodTempPrefix(prefix);
+        prefix = getCorrectTempPrefix(prefix);
         String errorMessage = "Cannot create a temporary file with prefix '" + prefix + "'";
         if (suffix == null) {
             suffix = "";
@@ -138,7 +138,7 @@ public class FileUtils {
         File tempDir = null;
         String errorMessage = "Cannot create a temporary directory with prefix '" + prefix + "'.";
         try {
-            tempDir = File.createTempFile(getGoodTempPrefix(prefix), "");
+            tempDir = File.createTempFile(getCorrectTempPrefix(prefix), "");
         } catch (IOException e) {
             throw new RuntimeException(errorMessage);
         }


### PR DESCRIPTION
I have changed how inserting CPOGs from files works, without affecting the previous functionality, but allowing the results from PGMiner to be inserted using this. This solves the issue of Workcraft not being able to insert certain types of `.cpog` files, as mentioned in #436.
