### PR TITLE
Made some changes to the PGMiner plugin to keep up-to-date with the latest version of PGMiner

### DIFF
--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tasks/PGMinerResultHandler.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tasks/PGMinerResultHandler.java
@@ -31,13 +31,11 @@ public class PGMinerResultHandler extends DummyProgressMonitor<ExternalProcessRe
     private VisualCPOG visualCpog;
     private WorkspaceEntry we;
     private boolean createNewWindow;
-    private File outputFile;
 
-    public PGMinerResultHandler(VisualCPOG visualCpog, WorkspaceEntry we, boolean createNewWindow, File outputFile) {
+    public PGMinerResultHandler(VisualCPOG visualCpog, WorkspaceEntry we, boolean createNewWindow) {
         this.visualCpog = visualCpog;
         this.we = we;
         this.createNewWindow = createNewWindow;
-        this.outputFile = outputFile;
     }
 
     public void finished(final Result<? extends ExternalProcessResult> result, String description) {
@@ -73,16 +71,19 @@ public class PGMinerResultHandler extends DummyProgressMonitor<ExternalProcessRe
                                 e.printStackTrace();
                             }
                         }
+                        String[] output = new String(result.getReturnValue().getOutput()).split("\n");
 
                         we.captureMemento();
+                        try {
+                            for (int i = 0; i < output.length; i++) {
+                                String exp = output[i];
+                                tool.insertExpression(exp, visualCpog, false, false, true, false);
+                            }
 
-
-                        if (tool.insertCpogFromFile(outputFile)) {
                             we.saveMemento();
-                        } else {
+                        } catch (Exception e) {
                             we.cancelMemento();
                         }
-
                     }
                 }
             });

--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tasks/PGMinerTask.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tasks/PGMinerTask.java
@@ -1,11 +1,7 @@
 package org.workcraft.plugins.cpog.tasks;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.workcraft.plugins.cpog.CpogSettings;
 import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
 import org.workcraft.plugins.shared.tasks.ExternalProcessTask;
@@ -14,7 +10,6 @@ import org.workcraft.tasks.Result;
 import org.workcraft.tasks.Result.Outcome;
 import org.workcraft.tasks.SubtaskMonitor;
 import org.workcraft.tasks.Task;
-import org.workcraft.util.FileUtils;
 import org.workcraft.util.ToolUtils;
 
 public class PGMinerTask implements Task<ExternalProcessResult> {
@@ -35,33 +30,23 @@ public class PGMinerTask implements Task<ExternalProcessResult> {
             String toolName = ToolUtils.getAbsoluteCommandPath(CpogSettings.getPgminerCommand());
             command.add(toolName);
 
-            if (split) {
-                command.add("-split");
-            }
             command.add(inputFile.getAbsolutePath());
+
+            if (split) {
+                command.add("-s");
+            }
 
             //Call PGMiner
             ExternalProcessTask task = new ExternalProcessTask(command, new File("."));
             SubtaskMonitor<Object> mon = new SubtaskMonitor<>(monitor);
-
             Result<? extends ExternalProcessResult> result = task.run(mon);
 
             if (result.getOutcome() != Outcome.FINISHED) {
-
                 return result;
-            }
-            Map<String, byte[]> outputFiles = new HashMap<>();
-            try {
-                File outputFile = getOutputFile(inputFile);
-                if (outputFile.exists()) {
-                    outputFiles.put("output.cpog", FileUtils.readAllBytes(outputFile));
-                }
-            } catch (IOException e) {
-                return new Result<ExternalProcessResult>(e);
             }
 
             ExternalProcessResult retVal = result.getReturnValue();
-            ExternalProcessResult finalResult = new ExternalProcessResult(retVal.getReturnCode(), retVal.getOutput(), retVal.getErrors(), outputFiles);
+            ExternalProcessResult finalResult = new ExternalProcessResult(retVal.getReturnCode(), retVal.getOutput(), retVal.getErrors(), null);
             if (retVal.getReturnCode() == 0) {
                 return Result.finished(finalResult);
             } else {
@@ -72,21 +57,6 @@ public class PGMinerTask implements Task<ExternalProcessResult> {
         }
 
         return null;
-    }
-
-    public File getOutputFile(File inputFile) {
-
-
-        String filePath = inputFile.getAbsolutePath();
-
-        int index = filePath.lastIndexOf('/');
-        String fileName = filePath.substring(index + 1);
-        String suffix = fileName.substring(fileName.indexOf('.'));
-        fileName = fileName.replace(suffix, "") + ".cpog";
-        filePath = filePath.substring(0, index + 1);
-        File outputFile = new File(filePath + fileName);
-
-        return outputFile;
     }
 
 

--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerImportTool.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerImportTool.java
@@ -1,8 +1,6 @@
 package org.workcraft.plugins.cpog.tools;
 
 import java.io.File;
-import java.io.PrintStream;
-import java.util.HashSet;
 import java.util.Scanner;
 
 import org.workcraft.Framework;
@@ -45,67 +43,8 @@ public class PGMinerImportTool implements Tool {
             return null;
         }
 
-        if (!dialog.getExtractConcurrency() || dialog.getSplit()) {
-            return new File(dialog.getFilePath());
-        }
 
-        try {
-            File inputFile = File.createTempFile("input", ".tr");
-            int c = 0;
-            File originalFile = new File(dialog.getFilePath());
-            Scanner k = new Scanner(originalFile);
-            while (k.hasNextLine()) {
-                c++;
-                k.nextLine();
-            }
-            k.close();
-
-            k = new Scanner(originalFile);
-            String[] lines = new String[c];
-
-            c = 0;
-            while (k.hasNext()) {
-                lines[c] = k.nextLine();
-                c++;
-            }
-            k.close();
-
-            HashSet<String> visitedEvents;
-            int i = 0;
-            String[] newLines = new String[lines.length];
-            for (String line : lines) {
-                String[] events = line.split(" ");
-                line = "";
-                visitedEvents = new HashSet<>();
-                for (String event : events) {
-                    if (visitedEvents.contains(event)) {
-                        int d = 1;
-                        while (visitedEvents.contains(event + "_" + d)) {
-                            d++;
-                        }
-                        event = event + "_" + d;
-                    }
-                    if (!line.isEmpty()) {
-                        line = line + " ";
-                    }
-                    line = line + event;
-                    visitedEvents.add(event);
-                }
-                newLines[i] = line;
-                i++;
-            }
-
-            PrintStream expressions = new PrintStream(inputFile);
-
-            for (String line : newLines) {
-                expressions.println(line);
-            }
-            expressions.close();
-            return inputFile;
-        } catch (Exception e) {
-            return null;
-        }
-
+        return new File(dialog.getFilePath());
     }
 
     @Override

--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerImportTool.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerImportTool.java
@@ -125,7 +125,7 @@ public class PGMinerImportTool implements Tool {
                 if (dialog.getExtractConcurrency()) {
                     PGMinerTask task = new PGMinerTask(inputFile, dialog.getSplit());
 
-                    PGMinerResultHandler result = new PGMinerResultHandler((VisualCPOG) we.getModelEntry().getVisualModel(), we, false, task.getOutputFile(inputFile));
+                    PGMinerResultHandler result = new PGMinerResultHandler((VisualCPOG) we.getModelEntry().getVisualModel(), we, false);
                     framework.getTaskManager().queue(task, "PGMiner", result);
                 } else {
                     Scanner k;

--- a/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerSelectedGraphsExtractionTool.java
+++ b/CpogsPlugin/src/org/workcraft/plugins/cpog/tools/PGMinerSelectedGraphsExtractionTool.java
@@ -32,13 +32,11 @@ public class PGMinerSelectedGraphsExtractionTool implements Tool {
     }
 
     public File getInputFile(WorkspaceEntry we) {
-        File inputFile = null;
         try {
             VisualCPOG visualCpog = (VisualCPOG) we.getModelEntry().getVisualModel();
             String allGraphs = CpogParsingTool.getExpressionFromGraph(visualCpog);
             ArrayList<String> tempGraphs = new ArrayList<>();
             ArrayList<String> graphs = new ArrayList<>();
-            inputFile = File.createTempFile("input", ".tr");
 
             int i = allGraphs.indexOf(" + ");
             while (i > -1) {
@@ -49,6 +47,8 @@ public class PGMinerSelectedGraphsExtractionTool implements Tool {
             allGraphs = allGraphs.replaceAll(" -> ", " ");
 
             String[] graphList = allGraphs.split("\n");
+
+            allGraphs = "";
 
             for (String g : graphList) tempGraphs.add(g);
 
@@ -68,17 +68,21 @@ public class PGMinerSelectedGraphsExtractionTool implements Tool {
                 graphs.add(graph);
             }
 
+            File inputFile = File.createTempFile("input", ".tr");
             PrintStream expressions = new PrintStream(inputFile);
 
-            for (String graph : graphs) {
+            for (String graph: graphs) {
                 expressions.println(graph);
             }
 
             expressions.close();
 
+            return inputFile;
+
         } catch (IOException exception) {
             exception.printStackTrace();
         } catch (ArrayIndexOutOfBoundsException e2) {
+
             JOptionPane.showMessageDialog(null,
                     "Error: No scenarios have been selected",
                     "Error",
@@ -86,19 +90,17 @@ public class PGMinerSelectedGraphsExtractionTool implements Tool {
             throw e2;
         }
 
-        return inputFile;
+        return null;
     }
 
     public void run(WorkspaceEntry we) {
 
         try {
 
-            File inputFile = getInputFile(we);
-            if (inputFile == null) return;
-            PGMinerTask task = new PGMinerTask(inputFile, false);
+            PGMinerTask task = new PGMinerTask(getInputFile(we), false);
 
             final Framework framework = Framework.getInstance();
-            PGMinerResultHandler result = new PGMinerResultHandler((VisualCPOG) we.getModelEntry().getVisualModel(), we, true, task.getOutputFile(inputFile));
+            PGMinerResultHandler result = new PGMinerResultHandler((VisualCPOG) we.getModelEntry().getVisualModel(), we, true);
             framework.getTaskManager().queue(task, "PGMiner", result);
         } catch (ArrayIndexOutOfBoundsException e) {
 


### PR DESCRIPTION
Event log files are now used as the default input for all process mining tasks.
Output from PGMiner is now read from `stdout` to reduce the number of temporary files.

I was attempting to set up so when CPOGs are selected to be mined (not from a file), they can be passed into `stdin` of pgminer, but this requires some changes of Workcraft Core files, which in future I may discuss with @danilovesky. 
