### PR TITLE
dist: fix POSIX compliance

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -43,7 +43,7 @@ if [ ! -e "$core_dir/build" ]; then
     err "You need to run './gradlew assemble' first"
 fi
 
-if [ -z "$@" ] || [ "$@" == "all" ]; then
+if [ -z "$@" ] || [ "$@" = "all" ]; then
     platforms="$allplatforms"
 else
     platforms="$@"


### PR DESCRIPTION
I mistakenly used == instead of =. The former is bash, the latter is
POSIX. This fixes the script for shells like dash.
