### PR TITLE
Fixed an issue in CPOGs where larger models wouldn't allow vertices to be rendered as labels.

### DIFF
--- a/CpogPlugin/src/org/workcraft/plugins/cpog/VisualVertex.java
+++ b/CpogPlugin/src/org/workcraft/plugins/cpog/VisualVertex.java
@@ -220,6 +220,7 @@ public class VisualVertex extends VisualComponent implements CpogFormulaVariable
     public boolean hitTestInLocalSpace(Point2D pointInLocalSpace) {
         Shape shape = getShape();
         if (getRenderType() == RenderType.LABEL) {
+            cacheLabelRenderedText(getLabel(), labelFont, getLabelPositioning(), getLabelOffset());
             shape = getLabelBoundingBox();
         }
         return shape.contains(pointInLocalSpace);


### PR DESCRIPTION
Andrey found the issue. 

Fixed it by making it cache the rendered text labels earlier. Otherwise with larger graphs, it can take too long to redraw the window before it's prepared the rendered label to be drawn, and as the vertex will already be set as a label, it panics and blocks everything. 
