### PR TITLE
Consistency supervisor for STG transitions names

### DIFF
--- a/StgPlugin/src/org/workcraft/plugins/stg/SignalTypeConsistencySupervisor.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/SignalTypeConsistencySupervisor.java
@@ -43,18 +43,24 @@ class SignalTypeConsistencySupervisor extends StateSupervisor {
         if (e instanceof PropertyChangedEvent) {
             PropertyChangedEvent pce = (PropertyChangedEvent) e;
             String propertyName = pce.getPropertyName();
-            if (propertyName.equals(SignalTransition.PROPERTY_SIGNAL_TYPE) || propertyName.equals(SignalTransition.PROPERTY_SIGNAL_NAME)) {
+            if (propertyName.equals(SignalTransition.PROPERTY_SIGNAL_TYPE) ||
+                    propertyName.equals(SignalTransition.PROPERTY_SIGNAL_NAME)) {
+
                 SignalTransition t = (SignalTransition) e.getSender();
                 String signalName = t.getSignalName();
                 Container container = (Container) t.getParent();
                 SignalTransition.Type signalType = t.getSignalType();
                 final Collection<SignalTransition> transitions = stg.getSignalTransitions(signalName, container);
+
                 if (propertyName.equals(SignalTransition.PROPERTY_SIGNAL_TYPE)) {
+                    // If transition type changed than change the type of all other transitions with the same signal name.
                     for (SignalTransition tt : transitions) {
                         tt.setSignalType(signalType);
                     }
                 }
+
                 if (propertyName.equals(SignalTransition.PROPERTY_SIGNAL_NAME)) {
+                    // If transition signal name changed than change its type to that of existing transitions of the same signal.
                     for (SignalTransition tt : transitions) {
                         if (tt == t) continue;
                         t.setSignalType(tt.getSignalType());
@@ -64,4 +70,5 @@ class SignalTypeConsistencySupervisor extends StateSupervisor {
             }
         }
     }
+
 }

--- a/StgPlugin/src/org/workcraft/plugins/stg/Stg.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/Stg.java
@@ -70,6 +70,7 @@ public class Stg extends AbstractMathModel implements StgModel {
         super(root, new StgReferenceManager(refs));
         referenceManager = (StgReferenceManager) getReferenceManager();
         new SignalTypeConsistencySupervisor(this).attach(getRoot());
+        new TransitionNameConsistencySupervisor(this).attach(getRoot());
     }
 
     public final Place createPlace() {

--- a/StgPlugin/src/org/workcraft/plugins/stg/StgNameManager.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/StgNameManager.java
@@ -222,7 +222,9 @@ public class StgNameManager extends UniqueNameManager {
             setPrefixCount(prefix, count);
             st.setSignalName(name);
             signalTransitions.put(name, st);
-            instancedNameManager.assign(st);
+            if (instancedNameManager.getInstance(st) == null) {
+                instancedNameManager.assign(st);
+            }
         }
     }
 
@@ -236,7 +238,9 @@ public class StgNameManager extends UniqueNameManager {
             } while (!isGoodDummyName(name));
             dt.setName(name);
             dummyTransitions.put(name, dt);
-            instancedNameManager.assign(dt);
+            if (instancedNameManager.getInstance(dt) == null) {
+                instancedNameManager.assign(dt);
+            }
         }
     }
 

--- a/StgPlugin/src/org/workcraft/plugins/stg/TransitionNameConsistencySupervisor.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/TransitionNameConsistencySupervisor.java
@@ -1,0 +1,61 @@
+/*
+*
+* Copyright 2008,2009 Newcastle University
+*
+* This file is part of Workcraft.
+*
+* Workcraft is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Workcraft is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Workcraft.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+/**
+ *
+ */
+package org.workcraft.plugins.stg;
+
+import org.workcraft.observation.PropertyChangedEvent;
+import org.workcraft.observation.StateEvent;
+import org.workcraft.observation.StateSupervisor;
+
+class TransitionNameConsistencySupervisor extends StateSupervisor {
+    private final Stg stg;
+
+    TransitionNameConsistencySupervisor(Stg stg) {
+        this.stg = stg;
+    }
+
+    @Override
+    public void handleEvent(StateEvent e) {
+        if (e instanceof PropertyChangedEvent) {
+            PropertyChangedEvent pce = (PropertyChangedEvent) e;
+            String propertyName = pce.getPropertyName();
+            if (propertyName.equals(SignalTransition.PROPERTY_SIGNAL_NAME) ||
+                    propertyName.equals(SignalTransition.PROPERTY_DIRECTION)) {
+
+                SignalTransition t = (SignalTransition) e.getSender();
+                String name = t.getName();
+                if (name != null) {
+                    String oldName = stg.getName(t);
+                    if (oldName != null) {
+                        oldName = LabelParser.getTransitionName(oldName);
+                    }
+                    if (!name.equals(oldName)) {
+                        stg.setName(t, name);
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/StgPlugin/src/org/workcraft/plugins/stg/VisualSignalTransition.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/VisualSignalTransition.java
@@ -82,31 +82,28 @@ public class VisualSignalTransition extends VisualNamedTransition implements Sta
     }
 
     @NoAutoSerialisation
-    public void setType(SignalTransition.Type type) {
+    public void setType(Type type) {
         getReferencedTransition().setSignalType(type);
-//        updateRenderedText();
     }
 
     @NoAutoSerialisation
-    public SignalTransition.Type getType() {
+    public Type getType() {
         return getReferencedTransition().getSignalType();
     }
 
     @NoAutoSerialisation
-    public void setDirection(SignalTransition.Direction direction) {
+    public void setDirection(Direction direction) {
         getReferencedTransition().setDirection(direction);
-        updateRenderedText();
     }
 
     @NoAutoSerialisation
-    public SignalTransition.Direction getDirection() {
+    public Direction getDirection() {
         return getReferencedTransition().getDirection();
     }
 
     @NoAutoSerialisation
     public void setSignalName(String name) {
         getReferencedTransition().setSignalName(name);
-        updateRenderedText();
     }
 
     @NoAutoSerialisation
@@ -124,7 +121,7 @@ public class VisualSignalTransition extends VisualNamedTransition implements Sta
 //    public void copyStyle(Stylable src) {
 //        super.copyStyle(src);
 //        if (src instanceof VisualSignalTransition) {
-//            VisualSignalTransition srcSignalTransition = (VisualSignalTransition)src;
+//            VisualSignalTransition srcSignalTransition = (VisualSignalTransition) src;
 //            setType(srcSignalTransition.getType());
 //            setDirection(srcSignalTransition.getDirection());
 //        }

--- a/StgPlugin/src/org/workcraft/plugins/stg/tools/MirrorTransitionTool.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tools/MirrorTransitionTool.java
@@ -66,7 +66,7 @@ public class MirrorTransitionTool extends TransformationTool implements NodeTran
 
     @Override
     public void transform(Model model, Node node) {
-        if (node instanceof VisualSignalTransition) {
+        if ((model instanceof VisualStg) && (node instanceof VisualSignalTransition)) {
             VisualSignalTransition signalTransition = (VisualSignalTransition) node;
             Direction direction = signalTransition.getDirection();
             if (direction == Direction.PLUS) {


### PR DESCRIPTION
Signal naming and direction of STG transitions is made
consistent with the STG reference manager.

Fixes #525.
