### PR TITLE
Editor now shows hint for moving.

### DIFF
--- a/WorkcraftCore/src/org/workcraft/gui/DesktopApi.java
+++ b/WorkcraftCore/src/org/workcraft/gui/DesktopApi.java
@@ -9,6 +9,7 @@ package org.workcraft.gui;
 import java.awt.Desktop;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.IOException;
@@ -214,6 +215,13 @@ public class DesktopApi {
             return e.isMetaDown();
         }
         return e.isControlDown();
+    }
+
+    public static int getMenuKeyCode() {
+        if (getOs().isMac()) {
+            return KeyEvent.VK_META;
+        }
+        return KeyEvent.VK_CONTROL;
     }
 
 }

--- a/WorkcraftCore/src/org/workcraft/gui/graph/tools/SelectionTool.java
+++ b/WorkcraftCore/src/org/workcraft/gui/graph/tools/SelectionTool.java
@@ -121,6 +121,7 @@ public class SelectionTool extends AbstractTool {
     private boolean enablePaging = true;
     private boolean enableFlipping = true;
     private boolean enableRotating = true;
+    private boolean isPanMode = false;
 
     public SelectionTool() {
         this(true, true, true, true);
@@ -283,6 +284,7 @@ public class SelectionTool extends AbstractTool {
     public void activated(final GraphEditor editor) {
         super.activated(editor);
         currentNode = null;
+        isPanMode = false;
     }
 
     @Override
@@ -626,6 +628,19 @@ public class SelectionTool extends AbstractTool {
                 break;
             }
         }
+
+        if (e.getKeyCode() == DesktopApi.getMenuKeyCode()) {
+            isPanMode = true;
+            e.getEditor().forceRedraw();
+        }
+    }
+
+    @Override
+    public void keyReleased(GraphEditorKeyEvent e) {
+        if (e.getKeyCode() == DesktopApi.getMenuKeyCode()) {
+            isPanMode = false;
+            e.getEditor().forceRedraw();
+        }
     }
 
     @Override
@@ -749,7 +764,7 @@ public class SelectionTool extends AbstractTool {
             }
 
             @Override
-            public void keyReleased(KeyEvent arg0) {
+            public void keyReleased(KeyEvent e) {
             }
 
             @Override
@@ -928,6 +943,10 @@ public class SelectionTool extends AbstractTool {
         editor.getWorkspaceEntry().saveMemento();
         // Redraw the editor window to recalculate all the bounding boxes
         editor.forceRedraw();
+    }
+
+    public String getHintMessage() {
+        return isPanMode ? "Use " + DesktopApi.getMenuKeyMaskName() + "+RMB to drag and move the editor" : null;
     }
 
 }


### PR DESCRIPTION
Pressing CTRL (cmd on OS X) will show a hint suggesting to use this and RMB to drag around the editor.

This should close #549 
