### PR TITLE
A fix for Ctrl+RMB panning issues. 

### DIFF
--- a/WorkcraftCore/src/org/workcraft/gui/graph/GraphEditorPanelMouseListener.java
+++ b/WorkcraftCore/src/org/workcraft/gui/graph/GraphEditorPanelMouseListener.java
@@ -124,7 +124,7 @@ class GraphEditorPanelMouseListener implements MouseMotionListener, MouseListene
     }
 
     public void mouseReleased(MouseEvent e) {
-        if (isPanCombo(e)) {
+        if (isPanCombo(e) || (e.getButton() == MouseEvent.BUTTON3 && panDrag)) {
             panDrag = false;
         } else {
             GraphEditorTool tool = toolProvider.getTool();


### PR DESCRIPTION
This will exit panning mode when both `Ctrl` and `RMB` are released in any order.

This should fix #553
