### PR TITLE
CPOG: All tool dialogs now exit with `esc`

### DIFF
--- a/CpogPlugin/src/org/workcraft/plugins/cpog/gui/AlgebraExportDialog.java
+++ b/CpogPlugin/src/org/workcraft/plugins/cpog/gui/AlgebraExportDialog.java
@@ -3,14 +3,17 @@ package org.workcraft.plugins.cpog.gui;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.io.File;
 
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 
 import org.workcraft.Framework;
 import org.workcraft.util.GUI;
@@ -60,6 +63,14 @@ public class AlgebraExportDialog extends JDialog {
         add(optionPanel);
         add(filePanel);
         add(okPanel);
+
+        getRootPane().registerKeyboardAction(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setVisible(false);
+            }
+        }, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+                JComponent.WHEN_IN_FOCUSED_WINDOW);
 
         pack();
         this.setLocationRelativeTo(Framework.getInstance().getMainWindow());

--- a/CpogPlugin/src/org/workcraft/plugins/cpog/gui/PGMinerImportDialog.java
+++ b/CpogPlugin/src/org/workcraft/plugins/cpog/gui/PGMinerImportDialog.java
@@ -4,17 +4,20 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.FileNotFoundException;
 
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 
 import org.workcraft.Framework;
 import org.workcraft.util.GUI;
@@ -72,6 +75,14 @@ public class PGMinerImportDialog extends JDialog {
         content.add(btnPanel, BorderLayout.SOUTH);
 
         setContentPane(content);
+
+        getRootPane().registerKeyboardAction(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setVisible(false);
+            }
+        }, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+                JComponent.WHEN_IN_FOCUSED_WINDOW);
 
         pack();
         this.setLocationRelativeTo(Framework.getInstance().getMainWindow());


### PR DESCRIPTION
This now occurs for the algebra and process mining plugin dialogs
