### PR TITLE
Concepts can now be imported. 

### DIFF
--- a/StgPlugin/src/org/workcraft/plugins/stg/StgModule.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/StgModule.java
@@ -14,6 +14,7 @@ import org.workcraft.plugins.stg.interop.DotGImporter;
 import org.workcraft.plugins.stg.serialisation.DotGSerialiser;
 import org.workcraft.plugins.stg.serialisation.ImplicitPlaceArcDeserialiser;
 import org.workcraft.plugins.stg.serialisation.ImplicitPlaceArcSerialiser;
+import org.workcraft.plugins.stg.tools.ConceptsTool;
 import org.workcraft.plugins.stg.tools.DummyInserterTool;
 import org.workcraft.plugins.stg.tools.DummyToSignalTransitionConverterTool;
 import org.workcraft.plugins.stg.tools.MakePlacesExplicitTool;
@@ -67,6 +68,7 @@ public class StgModule implements Module {
         pm.registerClass(Tool.class, StgToPetriConverterTool.class);
         pm.registerClass(Tool.class, MergeTransitionTool.class);
         pm.registerClass(Tool.class, DummyInserterTool.class);
+        pm.registerClass(Tool.class, ConceptsTool.class);
     }
 
     private void initCompatibilityManager() {

--- a/StgPlugin/src/org/workcraft/plugins/stg/StgModule.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/StgModule.java
@@ -9,6 +9,7 @@ import org.workcraft.dom.ModelDescriptor;
 import org.workcraft.gui.propertyeditor.Settings;
 import org.workcraft.interop.Exporter;
 import org.workcraft.interop.Importer;
+import org.workcraft.plugins.stg.interop.ConceptsImporter;
 import org.workcraft.plugins.stg.interop.DotGExporter;
 import org.workcraft.plugins.stg.interop.DotGImporter;
 import org.workcraft.plugins.stg.serialisation.DotGSerialiser;
@@ -53,6 +54,7 @@ public class StgModule implements Module {
 
         pm.registerClass(Exporter.class, DotGExporter.class);
         pm.registerClass(Importer.class, DotGImporter.class);
+        pm.registerClass(Importer.class, ConceptsImporter.class);
 
         pm.registerClass(ModelSerialiser.class, DotGSerialiser.class);
         pm.registerClass(Settings.class, StgSettings.class);

--- a/StgPlugin/src/org/workcraft/plugins/stg/StgSettings.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/StgSettings.java
@@ -27,6 +27,7 @@ import java.util.List;
 import javax.swing.JOptionPane;
 
 import org.workcraft.Config;
+import org.workcraft.gui.DesktopApi;
 import org.workcraft.gui.propertyeditor.PropertyDeclaration;
 import org.workcraft.gui.propertyeditor.PropertyDescriptor;
 import org.workcraft.gui.propertyeditor.Settings;
@@ -38,14 +39,17 @@ public class StgSettings implements Settings {
     private static final String keyDensityMapLevelLimit = prefix + ".densityMapLevelLimit";
     private static final String keyLowLevelSuffix = prefix + ".lowLevelSuffix";
     private static final String keyHighLevelSuffix = prefix + ".highLevelSuffix";
+    private static final String keyConceptsFolderLocation = prefix + ".conceptsFolderLocation";
 
     private static final Integer defaultDensityMapLevelLimit = 5;
     private static final String defaultLowLevelSuffix = "_LOW";
     private static final String defaultHighLevelSuffix = "_HIGH";
+    private static final String defaultConceptsFolderLocation = DesktopApi.getOs().isWindows() ? "tools\\concepts\\" : "tools/concepts/";
 
     private static Integer densityMapLevelLimit = defaultDensityMapLevelLimit;
     private static String lowLevelSuffix = defaultLowLevelSuffix;
     private static String highLevelSuffix = defaultHighLevelSuffix;
+    private static String conceptsFolderLocation = defaultConceptsFolderLocation;
 
     public StgSettings() {
         properties.add(new PropertyDeclaration<StgSettings, Integer>(
@@ -91,6 +95,16 @@ public class StgSettings implements Settings {
                 return getHighLevelSuffix();
             }
         });
+
+        properties.add(new PropertyDeclaration<StgSettings, String>(
+                this, "Concepts folder location", String.class, true, false, false) {
+            protected void setter(StgSettings object, String value) {
+                setConceptsFolderLocation(value);
+            }
+            protected String getter(StgSettings object) {
+                return getConceptsFolderLocation();
+            }
+        });
     }
 
     private boolean checkSignalLevelSuffix(String value) {
@@ -128,6 +142,7 @@ public class StgSettings implements Settings {
         setDensityMapLevelLimit(config.getInt(keyDensityMapLevelLimit, defaultDensityMapLevelLimit));
         setLowLevelSuffix(config.getString(keyLowLevelSuffix, defaultLowLevelSuffix));
         setHighLevelSuffix(config.getString(keyHighLevelSuffix, defaultHighLevelSuffix));
+        setConceptsFolderLocation(config.getString(keyConceptsFolderLocation, defaultConceptsFolderLocation));
     }
 
     @Override
@@ -135,6 +150,7 @@ public class StgSettings implements Settings {
         config.setInt(keyDensityMapLevelLimit, getDensityMapLevelLimit());
         config.set(keyLowLevelSuffix, getLowLevelSuffix());
         config.set(keyHighLevelSuffix, getHighLevelSuffix());
+        config.set(keyConceptsFolderLocation, getConceptsFolderLocation());
     }
 
     @Override
@@ -173,6 +189,14 @@ public class StgSettings implements Settings {
         if (value.length() > 0) {
             highLevelSuffix = value;
         }
+    }
+
+    public static String getConceptsFolderLocation() {
+        return conceptsFolderLocation;
+    }
+
+    public static void setConceptsFolderLocation(String value) {
+        conceptsFolderLocation = value;
     }
 
 }

--- a/StgPlugin/src/org/workcraft/plugins/stg/interop/ConceptsImporter.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/interop/ConceptsImporter.java
@@ -1,0 +1,64 @@
+package org.workcraft.plugins.stg.interop;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+
+import org.workcraft.exceptions.DeserialisationException;
+import org.workcraft.interop.Importer;
+import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
+import org.workcraft.plugins.stg.StgDescriptor;
+import org.workcraft.plugins.stg.StgModel;
+import org.workcraft.plugins.stg.tasks.ConceptsResultHandler;
+import org.workcraft.plugins.stg.tasks.ConceptsTask;
+import org.workcraft.plugins.stg.tools.ConceptsToolException;
+import org.workcraft.tasks.Result;
+import org.workcraft.tasks.Result.Outcome;
+import org.workcraft.util.FileUtils;
+import org.workcraft.workspace.ModelEntry;
+
+public class ConceptsImporter implements Importer {
+
+    private static final String GRAPH_KEYWORD = "module Concept where";
+    private File inputFile;
+
+    @Override
+    public boolean accept(File file) {
+        if (file.getName().endsWith(".hs")
+                && FileUtils.fileContainsKeyword(file, GRAPH_KEYWORD)) {
+            inputFile = file;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Concepts file (.hs)";
+    }
+
+    @Override
+    public ModelEntry importFrom(InputStream in) throws DeserialisationException {
+        try {
+            Result<? extends ExternalProcessResult> result = importConcepts();
+            if (result.getOutcome() == Outcome.FINISHED) {
+                String output = new String(result.getReturnValue().getOutput());
+                if (output.startsWith(".model")) {
+                    StgModel stg = new DotGImporter().importSTG(new ByteArrayInputStream(result.getReturnValue().getOutput()));
+                    return new ModelEntry(new StgDescriptor(), stg);
+                }
+            }
+            throw new ConceptsToolException(result);
+        } catch (ConceptsToolException e) {
+            e.handleConceptsError();
+            throw new DeserialisationException();
+        }
+    }
+
+    public Result<? extends ExternalProcessResult> importConcepts() throws DeserialisationException {
+        ConceptsTask task = new ConceptsTask(inputFile);
+        ConceptsResultHandler resultHandler = new ConceptsResultHandler(null);
+        return task.run(resultHandler);
+    }
+
+}

--- a/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsResultHandler.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsResultHandler.java
@@ -1,0 +1,80 @@
+package org.workcraft.plugins.stg.tasks;
+
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+import org.workcraft.Framework;
+import org.workcraft.exceptions.DeserialisationException;
+import org.workcraft.gui.MainWindow;
+import org.workcraft.gui.workspace.Path;
+import org.workcraft.plugins.shared.CommonEditorSettings;
+import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
+import org.workcraft.plugins.stg.interop.DotGImporter;
+import org.workcraft.tasks.DummyProgressMonitor;
+import org.workcraft.tasks.Result;
+import org.workcraft.tasks.Result.Outcome;
+import org.workcraft.util.FileUtils;
+import org.workcraft.util.Import;
+import org.workcraft.workspace.ModelEntry;
+import org.workcraft.workspace.WorkspaceEntry;
+
+public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessResult> {
+
+    private final WorkspaceEntry we;
+    private final String name;
+
+    public ConceptsResultHandler(WorkspaceEntry we, String inputName) {
+        this.we = we;
+        name = inputName;
+    }
+
+    public void finished(final Result<? extends ExternalProcessResult> result, String description) {
+        try {
+            SwingUtilities.invokeAndWait(new Runnable() {
+
+                @Override
+                public void run() {
+                    final Framework framework = Framework.getInstance();
+                    MainWindow mainWindow = framework.getMainWindow();
+
+                    
+                    if (result.getOutcome() == Outcome.FAILED) {
+                        if (result.getReturnValue().getReturnCode() == 2) {
+                            JOptionPane.showMessageDialog(mainWindow, "runghc could not run, please install the haskell compiler", "GHC not installed", JOptionPane.ERROR_MESSAGE);
+                        }
+
+                        JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+                    } else {
+                        try{
+                            String output = new String(result.getReturnValue().getOutput());
+                            if (output.startsWith(".model out")) {
+                                ModelEntry me = Import.importFromByteArray(new DotGImporter(), result.getReturnValue().getOutput());
+                                String title = "Concepts - ";
+                                me.getModel().setTitle(title);
+                                boolean openInEditor = me.isVisual() || CommonEditorSettings.getOpenNonvisual();
+                                framework.getWorkspace().add(Path.<String>empty(), name, me, false, openInEditor);
+                            } else {
+                                JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated.\nSee console window for error information", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+                                System.out.println(output);
+                            }
+                        } catch (IOException e) {
+                            // TODO Auto-generated catch block
+                            e.printStackTrace();
+                        } catch (DeserialisationException e) {
+                            // TODO Auto-generated catch block
+                            e.printStackTrace();
+                        }
+                       }
+                }
+            });
+        } catch (InvocationTargetException | InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsResultHandler.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsResultHandler.java
@@ -1,7 +1,5 @@
 package org.workcraft.plugins.stg.tasks;
 
-
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
@@ -18,18 +16,14 @@ import org.workcraft.plugins.stg.interop.DotGImporter;
 import org.workcraft.tasks.DummyProgressMonitor;
 import org.workcraft.tasks.Result;
 import org.workcraft.tasks.Result.Outcome;
-import org.workcraft.util.FileUtils;
 import org.workcraft.util.Import;
 import org.workcraft.workspace.ModelEntry;
-import org.workcraft.workspace.WorkspaceEntry;
 
 public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessResult> {
 
-    private final WorkspaceEntry we;
     private final String name;
 
-    public ConceptsResultHandler(WorkspaceEntry we, String inputName) {
-        this.we = we;
+    public ConceptsResultHandler(String inputName) {
         name = inputName;
     }
 
@@ -41,35 +35,43 @@ public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessR
                 public void run() {
                     final Framework framework = Framework.getInstance();
                     MainWindow mainWindow = framework.getMainWindow();
-
-                    
-                    if (result.getOutcome() == Outcome.FAILED) {
-                        if (result.getReturnValue().getReturnCode() == 2) {
-                            JOptionPane.showMessageDialog(mainWindow, "runghc could not run, please install the haskell compiler", "GHC not installed", JOptionPane.ERROR_MESSAGE);
-                        }
-
-                        JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
-                    } else {
-                        try{
+                    try {
+                        if (result.getOutcome() == Outcome.FAILED) {
+                            String errors = new String(result.getReturnValue().getErrors());
+                            System.out.println(errors);
+                            if (errors.contains("<no location info>")) {
+                                JOptionPane.showMessageDialog(mainWindow, "Concepts code could not be found. \n"
+                                        + "Download it from https://github.com/tuura/concepts. \n"
+                                        + "Ensure that the preferences menu points to the correct location of the concepts folder", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+                            } else if (errors.contains("Could not find module")) {
+                                String pkg = "tools/concepts"; //TODO: Use setting for concepts location
+                                JOptionPane.showMessageDialog(mainWindow, "Concepts could not be run. \n"
+                                        + "The " + pkg + " package needs to be installed via Cabal using the command \"cabal install " + pkg + "\"\n",
+                                        "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+                            } else {
+                                JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+                            }
+                        } else {
                             String output = new String(result.getReturnValue().getOutput());
                             if (output.startsWith(".model out")) {
                                 ModelEntry me = Import.importFromByteArray(new DotGImporter(), result.getReturnValue().getOutput());
                                 String title = "Concepts - ";
-                                me.getModel().setTitle(title);
+                                me.getModel().setTitle(title + name);
                                 boolean openInEditor = me.isVisual() || CommonEditorSettings.getOpenNonvisual();
-                                framework.getWorkspace().add(Path.<String>empty(), name, me, false, openInEditor);
+                                framework.getWorkspace().add(Path.<String>empty(), title + name, me, false, openInEditor);
                             } else {
-                                JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated.\nSee console window for error information", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+                                JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated."
+                                        + "\nSee console window for error information", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
                                 System.out.println(output);
                             }
-                        } catch (IOException e) {
-                            // TODO Auto-generated catch block
-                            e.printStackTrace();
-                        } catch (DeserialisationException e) {
-                            // TODO Auto-generated catch block
-                            e.printStackTrace();
                         }
-                       }
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    } catch (DeserialisationException e) {
+                        e.printStackTrace();
+                    } catch (NullPointerException e) {
+                        JOptionPane.showMessageDialog(mainWindow, "runghc could not run, please install Haskell", "GHC not installed", JOptionPane.ERROR_MESSAGE);
+                    }
                 }
             });
         } catch (InvocationTargetException | InterruptedException e) {

--- a/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsResultHandler.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsResultHandler.java
@@ -17,6 +17,7 @@ import org.workcraft.tasks.DummyProgressMonitor;
 import org.workcraft.tasks.Result;
 import org.workcraft.tasks.Result.Outcome;
 import org.workcraft.util.Import;
+import org.workcraft.util.LogUtils;
 import org.workcraft.workspace.ModelEntry;
 
 public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessResult> {
@@ -38,7 +39,7 @@ public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessR
                     try {
                         if (result.getOutcome() == Outcome.FAILED) {
                             String errors = new String(result.getReturnValue().getErrors());
-                            System.out.println(errors);
+                            System.out.println(LogUtils.PREFIX_STDERR + errors);
                             if (errors.contains("<no location info>")) {
                                 JOptionPane.showMessageDialog(mainWindow, "Concepts code could not be found. \n"
                                         + "Download it from https://github.com/tuura/concepts. \n"
@@ -62,7 +63,7 @@ public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessR
                             } else {
                                 JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated."
                                         + "\nSee console window for error information", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
-                                System.out.println(output);
+                                System.out.println(LogUtils.PREFIX_STDERR + output);
                             }
                         }
                     } catch (IOException e) {

--- a/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsResultHandler.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsResultHandler.java
@@ -1,5 +1,6 @@
 package org.workcraft.plugins.stg.tasks;
 
+import java.awt.Container;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
@@ -8,10 +9,14 @@ import javax.swing.SwingUtilities;
 
 import org.workcraft.Framework;
 import org.workcraft.exceptions.DeserialisationException;
+import org.workcraft.gui.DockableWindowContentPanel;
 import org.workcraft.gui.MainWindow;
+import org.workcraft.gui.DockableWindowContentPanel.ViewAction;
+import org.workcraft.gui.graph.GraphEditorPanel;
 import org.workcraft.gui.workspace.Path;
 import org.workcraft.plugins.shared.CommonEditorSettings;
 import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
+import org.workcraft.plugins.stg.VisualStg;
 import org.workcraft.plugins.stg.interop.DotGImporter;
 import org.workcraft.tasks.DummyProgressMonitor;
 import org.workcraft.tasks.Result;
@@ -19,13 +24,16 @@ import org.workcraft.tasks.Result.Outcome;
 import org.workcraft.util.Import;
 import org.workcraft.util.LogUtils;
 import org.workcraft.workspace.ModelEntry;
+import org.workcraft.workspace.WorkspaceEntry;
 
 public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessResult> {
 
     private final String name;
+    private final WorkspaceEntry we;
 
-    public ConceptsResultHandler(String inputName) {
+    public ConceptsResultHandler(String inputName, WorkspaceEntry we) {
         name = inputName;
+        this.we = we;
     }
 
     public void finished(final Result<? extends ExternalProcessResult> result, String description) {
@@ -36,6 +44,7 @@ public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessR
                 public void run() {
                     final Framework framework = Framework.getInstance();
                     MainWindow mainWindow = framework.getMainWindow();
+                    GraphEditorPanel editor = mainWindow.getEditor(we);
                     try {
                         if (result.getOutcome() == Outcome.FAILED) {
                             String errors = new String(result.getReturnValue().getErrors());
@@ -56,10 +65,14 @@ public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessR
                             String output = new String(result.getReturnValue().getOutput());
                             if (output.startsWith(".model out")) {
                                 ModelEntry me = Import.importFromByteArray(new DotGImporter(), result.getReturnValue().getOutput());
+                                if (isCurrentWorkEmpty(editor)) {
+                                    closeEmptyWork(editor);
+                                }
                                 String title = "Concepts - ";
                                 me.getModel().setTitle(title + name);
                                 boolean openInEditor = me.isVisual() || CommonEditorSettings.getOpenNonvisual();
                                 framework.getWorkspace().add(Path.<String>empty(), title + name, me, false, openInEditor);
+
                             } else {
                                 JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated."
                                         + "\nSee console window for error information", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
@@ -78,6 +91,28 @@ public class ConceptsResultHandler extends DummyProgressMonitor<ExternalProcessR
         } catch (InvocationTargetException | InterruptedException e) {
             e.printStackTrace();
         }
+    }
+
+    private void closeEmptyWork(GraphEditorPanel editor) {
+        Container p = editor.getParent();
+
+        while (!(p instanceof DockableWindowContentPanel) && (p != null)) {
+            p = p.getParent();
+        }
+
+        if (p instanceof DockableWindowContentPanel) {
+            DockableWindowContentPanel d = (DockableWindowContentPanel) p;
+            new ViewAction(d.getID(), ViewAction.CLOSE_ACTION).run();
+        }
+    }
+
+    private boolean isCurrentWorkEmpty(GraphEditorPanel editor) {
+        VisualStg visualStg = (VisualStg) editor.getModel();
+        visualStg.selectAll();
+        if (visualStg.getSelection().isEmpty()) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsTask.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsTask.java
@@ -3,8 +3,10 @@ package org.workcraft.plugins.stg.tasks;
 import java.io.File;
 import java.util.ArrayList;
 
+import org.workcraft.gui.DesktopApi;
 import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
 import org.workcraft.plugins.shared.tasks.ExternalProcessTask;
+import org.workcraft.plugins.stg.StgSettings;
 import org.workcraft.tasks.ProgressMonitor;
 import org.workcraft.tasks.Result;
 import org.workcraft.tasks.SubtaskMonitor;
@@ -25,7 +27,8 @@ public class ConceptsTask implements Task<ExternalProcessResult> {
             ArrayList<String> command = new ArrayList<>();
 
             command.add("runghc");
-            command.add("tools/concepts/translate/Main.hs"); //TODO: Make concepts folder location a setting
+            String translateLocation = DesktopApi.getOs().isWindows() ? "translate\\Main.hs" : "translate/Main.hs";
+            command.add(StgSettings.getConceptsFolderLocation() + translateLocation); //TODO: Make concepts folder location a setting
             command.add(inputFile.getAbsolutePath());
 
             ExternalProcessTask task = new ExternalProcessTask(command, new File("."));

--- a/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsTask.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsTask.java
@@ -34,11 +34,9 @@ public class ConceptsTask implements Task<ExternalProcessResult> {
             ExternalProcessTask task = new ExternalProcessTask(command, new File("."));
             SubtaskMonitor<Object> mon = new SubtaskMonitor<>(monitor);
             Result<? extends ExternalProcessResult> result = task.run(mon);
-
             if (result.getOutcome() != Outcome.FINISHED) {
                 return result;
             }
-
             ExternalProcessResult retVal = result.getReturnValue();
             ExternalProcessResult finalResult = new ExternalProcessResult(retVal.getReturnCode(), retVal.getOutput(), retVal.getErrors(), null);
             if (retVal.getReturnCode() == 0) {

--- a/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsTask.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsTask.java
@@ -1,0 +1,54 @@
+package org.workcraft.plugins.stg.tasks;
+
+import java.io.File;
+import java.util.ArrayList;
+
+
+import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
+import org.workcraft.plugins.shared.tasks.ExternalProcessTask;
+import org.workcraft.tasks.ProgressMonitor;
+import org.workcraft.tasks.Result;
+import org.workcraft.tasks.SubtaskMonitor;
+import org.workcraft.tasks.Task;
+import org.workcraft.tasks.Result.Outcome;
+
+public class ConceptsTask implements Task<ExternalProcessResult>{
+
+    private File inputFile;
+
+    public ConceptsTask(File inputFile) {
+        this.inputFile = inputFile;
+    }
+
+    @Override
+    public Result<? extends ExternalProcessResult> run(ProgressMonitor<? super ExternalProcessResult> monitor) {
+        try {
+            ArrayList<String> command = new ArrayList<>();
+
+            command.add("./runghc");
+            command.add("tools/concepts/translate/Main.hs");//TODO: Make translate file location a setting
+            command.add(inputFile.getAbsolutePath());
+
+            ExternalProcessTask task = new ExternalProcessTask(command, new File("."));
+            SubtaskMonitor<Object> mon = new SubtaskMonitor<>(monitor);
+            Result<? extends ExternalProcessResult> result = task.run(mon);
+
+            if (result.getOutcome() != Outcome.FINISHED) {
+                return result;
+            }
+
+            ExternalProcessResult retVal = result.getReturnValue();
+            ExternalProcessResult finalResult = new ExternalProcessResult(retVal.getReturnCode(), retVal.getOutput(), retVal.getErrors(), null);
+            if (retVal.getReturnCode() == 0) {
+                return Result.finished(finalResult);
+            } else {
+                return Result.failed(finalResult);
+            }
+        } catch (NullPointerException e) {
+            //Open window dialog was cancelled, do nothing
+        }
+
+        return null;
+    }
+
+}

--- a/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsTask.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tasks/ConceptsTask.java
@@ -3,7 +3,6 @@ package org.workcraft.plugins.stg.tasks;
 import java.io.File;
 import java.util.ArrayList;
 
-
 import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
 import org.workcraft.plugins.shared.tasks.ExternalProcessTask;
 import org.workcraft.tasks.ProgressMonitor;
@@ -12,9 +11,9 @@ import org.workcraft.tasks.SubtaskMonitor;
 import org.workcraft.tasks.Task;
 import org.workcraft.tasks.Result.Outcome;
 
-public class ConceptsTask implements Task<ExternalProcessResult>{
+public class ConceptsTask implements Task<ExternalProcessResult> {
 
-    private File inputFile;
+    private final File inputFile;
 
     public ConceptsTask(File inputFile) {
         this.inputFile = inputFile;
@@ -25,8 +24,8 @@ public class ConceptsTask implements Task<ExternalProcessResult>{
         try {
             ArrayList<String> command = new ArrayList<>();
 
-            command.add("./runghc");
-            command.add("tools/concepts/translate/Main.hs");//TODO: Make translate file location a setting
+            command.add("runghc");
+            command.add("tools/concepts/translate/Main.hs"); //TODO: Make concepts folder location a setting
             command.add(inputFile.getAbsolutePath());
 
             ExternalProcessTask task = new ExternalProcessTask(command, new File("."));
@@ -47,7 +46,6 @@ public class ConceptsTask implements Task<ExternalProcessResult>{
         } catch (NullPointerException e) {
             //Open window dialog was cancelled, do nothing
         }
-
         return null;
     }
 

--- a/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsTool.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsTool.java
@@ -1,0 +1,69 @@
+package org.workcraft.plugins.stg.tools;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Scanner;
+
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import org.workcraft.plugins.stg.VisualStg;
+import org.workcraft.plugins.stg.tasks.ConceptsResultHandler;
+import org.workcraft.plugins.stg.tasks.ConceptsTask;
+import org.workcraft.Framework;
+import org.workcraft.Tool;
+import org.workcraft.workspace.WorkspaceEntry;
+
+public class ConceptsTool implements Tool {
+
+    public String getSection() {
+        return "! Concepts";
+    }
+
+    public String getDisplayName() {
+        return "Import concepts...";
+    }
+
+    public boolean isApplicableTo(WorkspaceEntry we) {
+        if (we.getModelEntry() == null) return false;
+        if (we.getModelEntry().getVisualModel() instanceof VisualStg) return true;
+        return false;
+    }
+
+    public File getInputFile() {
+        File inputFile = null;
+        JFileChooser chooser = new JFileChooser();
+        chooser.setFileFilter(new FileNameExtensionFilter("Haskell/Concept file (.hs)", "hs"));
+        if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+            File f = chooser.getSelectedFile();
+            try {
+                if (!f.exists()) {
+                    throw new FileNotFoundException();
+                }
+
+                inputFile = f;
+
+            } catch (FileNotFoundException e1) {
+                // TODO Auto-generated catch block
+                JOptionPane.showMessageDialog(null, e1.getMessage(),
+                        "File not found error", JOptionPane.ERROR_MESSAGE);
+                inputFile = null;
+            }
+        }
+        return inputFile;
+    }
+
+    @Override
+    public void run(WorkspaceEntry we) {
+        File inputFile = getInputFile();
+        if (inputFile == null) return;
+
+        ConceptsTask task = new ConceptsTask(inputFile);
+
+        ConceptsResultHandler result = new ConceptsResultHandler(we, inputFile.getName());
+
+        Framework.getInstance().getTaskManager().queue(task, "PGMiner", result);
+    }
+
+}

--- a/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsTool.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsTool.java
@@ -2,7 +2,6 @@ package org.workcraft.plugins.stg.tools;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.Scanner;
 
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -61,9 +60,9 @@ public class ConceptsTool implements Tool {
 
         ConceptsTask task = new ConceptsTask(inputFile);
 
-        ConceptsResultHandler result = new ConceptsResultHandler(we, inputFile.getName());
+        ConceptsResultHandler result = new ConceptsResultHandler(inputFile.getName());
 
-        Framework.getInstance().getTaskManager().queue(task, "PGMiner", result);
+        Framework.getInstance().getTaskManager().queue(task, "Translating concepts", result);
     }
 
 }

--- a/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsTool.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsTool.java
@@ -10,6 +10,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import org.workcraft.plugins.stg.VisualStg;
 import org.workcraft.plugins.stg.tasks.ConceptsResultHandler;
 import org.workcraft.plugins.stg.tasks.ConceptsTask;
+import org.workcraft.util.FileUtils;
 import org.workcraft.Framework;
 import org.workcraft.Tool;
 import org.workcraft.workspace.WorkspaceEntry;
@@ -60,7 +61,7 @@ public class ConceptsTool implements Tool {
 
         ConceptsTask task = new ConceptsTask(inputFile);
 
-        ConceptsResultHandler result = new ConceptsResultHandler(inputFile.getName(), we);
+        ConceptsResultHandler result = new ConceptsResultHandler(this, FileUtils.getFileNameWithoutExtension(inputFile), we);
 
         Framework.getInstance().getTaskManager().queue(task, "Translating concepts", result);
     }

--- a/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsTool.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsTool.java
@@ -60,7 +60,7 @@ public class ConceptsTool implements Tool {
 
         ConceptsTask task = new ConceptsTask(inputFile);
 
-        ConceptsResultHandler result = new ConceptsResultHandler(inputFile.getName());
+        ConceptsResultHandler result = new ConceptsResultHandler(inputFile.getName(), we);
 
         Framework.getInstance().getTaskManager().queue(task, "Translating concepts", result);
     }

--- a/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsToolException.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/tools/ConceptsToolException.java
@@ -1,0 +1,74 @@
+package org.workcraft.plugins.stg.tools;
+
+import javax.swing.JOptionPane;
+
+import org.workcraft.Framework;
+import org.workcraft.gui.MainWindow;
+import org.workcraft.plugins.shared.tasks.ExternalProcessResult;
+import org.workcraft.plugins.stg.StgSettings;
+import org.workcraft.tasks.Result;
+import org.workcraft.tasks.Result.Outcome;
+import org.workcraft.util.LogUtils;
+
+@SuppressWarnings("serial")
+public class ConceptsToolException extends Exception {
+
+    private static final MainWindow mainWindow = Framework.getInstance().getMainWindow();
+    private final Result<? extends ExternalProcessResult> result;
+
+    public ConceptsToolException(Result<? extends ExternalProcessResult> result) {
+        this.result = result;
+    }
+
+    public void handleConceptsError() {
+        try {
+            if (result.getOutcome() == Outcome.FAILED) {
+                String errors = new String(result.getReturnValue().getErrors());
+                System.out.println(LogUtils.PREFIX_STDERR + errors);
+                if (errors.contains("<no location info>")) {
+                    conceptsCodeNotFound();
+                } else if (errors.contains("Could not find module")) {
+                    conceptsNotInstalled();
+                } else {
+                    defaultError();
+                }
+            } else {
+                String output = new String(result.getReturnValue().getOutput());
+                if (!output.startsWith(".model out")) {
+                    cannotTranslateConceptsError(output);
+                }
+            }
+        } catch (NullPointerException e) {
+            ghcNotFound();
+        }
+    }
+
+    private void ghcNotFound() {
+        JOptionPane.showMessageDialog(mainWindow, "runghc could not run, please install Haskell", "GHC not installed", JOptionPane.ERROR_MESSAGE);
+    }
+
+    private void conceptsCodeNotFound() {
+        JOptionPane.showMessageDialog(mainWindow, "Concepts code could not be found. \n"
+                + "Download it from https://github.com/tuura/concepts. \n"
+                + "Ensure that the preferences menu points to the correct location of the concepts folder", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+    }
+
+    private void conceptsNotInstalled() {
+        String pkg = StgSettings.getConceptsFolderLocation();
+        JOptionPane.showMessageDialog(mainWindow, "Concepts could not be run. \n"
+                + "The " + pkg + " package needs to be installed via Cabal using the command \"cabal install " + pkg + "\"\n",
+                "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+    }
+
+    private void defaultError() {
+        JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+    }
+
+    private void cannotTranslateConceptsError(String output) {
+
+        System.out.println(LogUtils.PREFIX_STDERR + output);
+
+        JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated."
+                + "\nSee console window for error information", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+    }
+}

--- a/WorkcraftCore/src/org/workcraft/gui/MainWindow.java
+++ b/WorkcraftCore/src/org/workcraft/gui/MainWindow.java
@@ -363,8 +363,9 @@ public class MainWindow extends JFrame {
         LookAndFeelHelper.setDefaultLookAndFeel();
         SwingUtilities.updateComponentTreeUI(this);
 
-        if (DesktopApi.getOs().isMac())
+        if (DesktopApi.getOs().isMac()) {
             mainMenu.setUI(menuUI);
+        }
 
         content = new JPanel(new BorderLayout(0, 0));
         setContentPane(content);

--- a/WorkcraftCore/src/org/workcraft/gui/MainWindow.java
+++ b/WorkcraftCore/src/org/workcraft/gui/MainWindow.java
@@ -363,7 +363,8 @@ public class MainWindow extends JFrame {
         LookAndFeelHelper.setDefaultLookAndFeel();
         SwingUtilities.updateComponentTreeUI(this);
 
-        if (DesktopApi.getOs().isMac()) mainMenu.setUI(menuUI);
+        if (DesktopApi.getOs().isMac())
+            mainMenu.setUI(menuUI);
 
         content = new JPanel(new BorderLayout(0, 0));
         setContentPane(content);
@@ -563,7 +564,6 @@ public class MainWindow extends JFrame {
         pm.setCurrentPerspective(FLEXDOCK_WORKSPACE, true);
         PropertyManager.getDockingPortRoot().setTabPlacement(SwingConstants.TOP);
 
-
         File file = new File(Framework.UILAYOUT_FILE_PATH);
         PersistenceHandler persister = new FilePersistenceHandler(file, XMLPersister.newDefaultInstance());
         PerspectiveManager.setPersistenceHandler(persister);
@@ -597,16 +597,16 @@ public class MainWindow extends JFrame {
                 DockableWindowContentPanel.HEADER | DockableWindowContentPanel.CLOSE_BUTTON, DockingManager.EAST_REGION,
                 xSplit);
 
-        DockableWindow propertyEditorDockable = createDockableWindow(propertyEditorWindow, TITLE_PROPERTY_EDITOR, workspaceDockable,
-                DockableWindowContentPanel.HEADER | DockableWindowContentPanel.CLOSE_BUTTON,
+        DockableWindow propertyEditorDockable = createDockableWindow(propertyEditorWindow, TITLE_PROPERTY_EDITOR,
+                workspaceDockable, DockableWindowContentPanel.HEADER | DockableWindowContentPanel.CLOSE_BUTTON,
                 DockingManager.NORTH_REGION, ySplit);
 
-        DockableWindow toolControlsDockable = createDockableWindow(editorToolsWindow, TITLE_TOOL_CONTROLS, propertyEditorDockable,
-                DockableWindowContentPanel.HEADER | DockableWindowContentPanel.CLOSE_BUTTON,
+        DockableWindow toolControlsDockable = createDockableWindow(editorToolsWindow, TITLE_TOOL_CONTROLS,
+                propertyEditorDockable, DockableWindowContentPanel.HEADER | DockableWindowContentPanel.CLOSE_BUTTON,
                 DockingManager.SOUTH_REGION, 0.4f);
 
-        DockableWindow editorToolsDockable = createDockableWindow(toolControlsWindow, TITLE_EDITOR_TOOLS, toolControlsDockable,
-                DockableWindowContentPanel.HEADER | DockableWindowContentPanel.CLOSE_BUTTON,
+        DockableWindow editorToolsDockable = createDockableWindow(toolControlsWindow, TITLE_EDITOR_TOOLS,
+                toolControlsDockable, DockableWindowContentPanel.HEADER | DockableWindowContentPanel.CLOSE_BUTTON,
                 DockingManager.SOUTH_REGION, 0.795f);
 
         documentPlaceholder = createDockableWindow(new DocumentPlaceholder(), TITLE_PLACEHOLDER, null, outputDockable,
@@ -628,8 +628,8 @@ public class MainWindow extends JFrame {
         final Framework framework = Framework.getInstance();
         if (framework.getWorkspace().isChanged() && !framework.getWorkspace().isTemporary()) {
             int result = JOptionPane.showConfirmDialog(this,
-                    "Current workspace has unsaved changes.\n" + "Save before closing?",
-                    DIALOG_CLOSE_WORK, JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+                    "Current workspace has unsaved changes.\n" + "Save before closing?", DIALOG_CLOSE_WORK,
+                    JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
 
             switch (result) {
             case JOptionPane.YES_OPTION:
@@ -895,8 +895,8 @@ public class MainWindow extends JFrame {
                     break;
                 }
                 if (JOptionPane.showConfirmDialog(this,
-                        "The file '" + f.getName() + "' already exists.\n" + "Overwrite it?",
-                        DIALOG_SAVE_WORK, JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
+                        "The file '" + f.getName() + "' already exists.\n" + "Overwrite it?", DIALOG_SAVE_WORK,
+                        JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
                     break;
                 }
             } else {
@@ -1175,19 +1175,16 @@ public class MainWindow extends JFrame {
             title = "File access error";
         }
         if (!file.exists()) {
-            JOptionPane.showMessageDialog(this,
-                    "The path  \"" + file.getPath() + "\" does not exisit.\n",
-                    title, JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "The path  \"" + file.getPath() + "\" does not exisit.\n", title,
+                    JOptionPane.ERROR_MESSAGE);
             result = false;
         } else if (!file.isFile()) {
-            JOptionPane.showMessageDialog(this,
-                    "The path  \"" + file.getPath() + "\" is not a file.\n",
-                    title, JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "The path  \"" + file.getPath() + "\" is not a file.\n", title,
+                    JOptionPane.ERROR_MESSAGE);
             result = false;
         } else if (!file.canRead()) {
-            JOptionPane.showMessageDialog(this,
-                    "The file  \"" + file.getPath() + "\" cannot be read.\n",
-                    title, JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(this, "The file  \"" + file.getPath() + "\" cannot be read.\n", title,
+                    JOptionPane.ERROR_MESSAGE);
             result = false;
         }
         return result;
@@ -1202,8 +1199,8 @@ public class MainWindow extends JFrame {
 
     public void refreshWorkspaceEntryTitle(WorkspaceEntry we, boolean updateHeaders) {
         for (DockableWindow w : editorWindows.get(we)) {
-//            final GraphEditorPanel editor = getCurrentEditor();
-//            String title = getTitle(we, editor.getModel());
+            // final GraphEditorPanel editor = getCurrentEditor();
+            // String title = getTitle(we, editor.getModel());
             String title = getTitle(we);
             w.setTitle(title);
         }
@@ -1384,8 +1381,8 @@ public class MainWindow extends JFrame {
                 "This will reset the GUI to the default layout.\n" + "Are you sure you want to do this?",
                 DIALOG_RESET_LAYOUT, JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
             if (JOptionPane.showConfirmDialog(this,
-                    "This action requires GUI restart.\n\n" + "Close all editor windows?",
-                    DIALOG_RESET_LAYOUT, JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
+                    "This action requires GUI restart.\n\n" + "Close all editor windows?", DIALOG_RESET_LAYOUT,
+                    JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
                 try {
                     final Framework framework = Framework.getInstance();
                     framework.shutdownGUI();

--- a/WorkcraftCore/src/org/workcraft/util/Import.java
+++ b/WorkcraftCore/src/org/workcraft/util/Import.java
@@ -21,6 +21,7 @@
 
 package org.workcraft.util;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -49,6 +50,13 @@ public class Import {
             }
         }
         return null;
+    }
+
+    public static ModelEntry importFromByteArray(Importer importer, byte[] array) throws IOException, DeserialisationException {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(array);
+        ModelEntry model = importer.importFrom(inputStream);
+        inputStream.close();
+        return model;
     }
 
 }


### PR DESCRIPTION
This is the first step towards #560.

Concepts can be imported from the `File > Import` menu.
There is also a Concepts menu in the STG plugin, where concepts can also be imported.

Errors that occur are handled by `ConceptsToolException` in `...stg.tools`

If necessary, I can remove the Concepts menu for now, without affecting `ConceptsImporter`.

The next step is to create a dialog for users to type out concepts for quick tests. These concepts will be imported into the current work, probably as a page, rather than open a new work. 
