### PR TITLE
Added a new error messages for Concepts tool.

### DIFF
--- a/FstPlugin/src/org/workcraft/plugins/fst/tools/StgToFstConverterTool.java
+++ b/FstPlugin/src/org/workcraft/plugins/fst/tools/StgToFstConverterTool.java
@@ -19,6 +19,10 @@ public class StgToFstConverterTool extends ConversionTool {
         return WorkspaceUtils.isApplicable(we, Stg.class);
     }
 
+    public Position getPosition() {
+        return Position.TOP;
+    }
+
     @Override
     public String getDisplayName() {
         return isBinary() ? "Finate State Transducer (binary-encoded) [Petrify]" : "Finate State Transducer (basic) [Petrify]";

--- a/PetrifyPlugin/src/org/workcraft/plugins/petrify/tools/PetrifyDummyContraction.java
+++ b/PetrifyPlugin/src/org/workcraft/plugins/petrify/tools/PetrifyDummyContraction.java
@@ -15,6 +15,10 @@ public class PetrifyDummyContraction extends ConversionTool {
         return "Dummy contraction [Petrify]";
     }
 
+    public Position getPosition() {
+        return Position.TOP;
+    }
+
     @Override
     public boolean isApplicableTo(WorkspaceEntry we) {
         return WorkspaceUtils.isApplicable(we, StgModel.class);

--- a/PetrifyPlugin/src/org/workcraft/plugins/petrify/tools/PetrifyNetSynthesis.java
+++ b/PetrifyPlugin/src/org/workcraft/plugins/petrify/tools/PetrifyNetSynthesis.java
@@ -22,7 +22,7 @@ public class PetrifyNetSynthesis extends ConversionTool {
 
     @Override
     public Position getPosition() {
-        return Position.BOTTOM;
+        return Position.MIDDLE;
     }
 
     @Override

--- a/PetrifyPlugin/src/org/workcraft/plugins/petrify/tools/PetrifyUntoggle.java
+++ b/PetrifyPlugin/src/org/workcraft/plugins/petrify/tools/PetrifyUntoggle.java
@@ -15,6 +15,10 @@ public class PetrifyUntoggle extends ConversionTool {
         return "Untoggle signal transitions [Petrify]";
     }
 
+    public Position getPosition() {
+        return Position.TOP;
+    }
+
     @Override
     public boolean isApplicableTo(WorkspaceEntry we) {
         return WorkspaceUtils.isApplicable(we, StgModel.class);

--- a/StgPlugin/src/org/workcraft/plugins/stg/StgModule.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/StgModule.java
@@ -9,7 +9,6 @@ import org.workcraft.dom.ModelDescriptor;
 import org.workcraft.gui.propertyeditor.Settings;
 import org.workcraft.interop.Exporter;
 import org.workcraft.interop.Importer;
-import org.workcraft.plugins.stg.concepts.ConceptsTool;
 import org.workcraft.plugins.stg.concepts.ConceptsWritingTool;
 import org.workcraft.plugins.stg.interop.ConceptsImporter;
 import org.workcraft.plugins.stg.interop.DotGExporter;

--- a/StgPlugin/src/org/workcraft/plugins/stg/StgModule.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/StgModule.java
@@ -71,7 +71,6 @@ public class StgModule implements Module {
         pm.registerClass(Tool.class, StgToPetriConverterTool.class);
         pm.registerClass(Tool.class, MergeTransitionTool.class);
         pm.registerClass(Tool.class, DummyInserterTool.class);
-        pm.registerClass(Tool.class, ConceptsTool.class);
         pm.registerClass(Tool.class, ConceptsWritingTool.class);
     }
 

--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsToolException.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsToolException.java
@@ -35,7 +35,11 @@ public class ConceptsToolException extends Exception {
             } else {
                 String output = new String(result.getReturnValue().getOutput());
                 if (!output.startsWith(".model out")) {
-                    cannotTranslateConceptsError(output);
+                    if (output.contains("following signals have not been declared as a type")) {
+                        signalTypeNotDeclared(output);
+                    } else {
+                        cannotTranslateConceptsError(output);
+                    }
                 }
             }
         } catch (NullPointerException e) {
@@ -71,4 +75,16 @@ public class ConceptsToolException extends Exception {
         JOptionPane.showMessageDialog(mainWindow, "Concepts could not be translated."
                 + "\nSee console window for error information", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
     }
+
+    private void signalTypeNotDeclared(String output) {
+
+        System.out.println(LogUtils.PREFIX_STDERR + output);
+
+        JOptionPane.showMessageDialog(mainWindow, ""
+                + "One or more signals have not had their type declared. A list of these can be found in the console window.\n"
+                + "This can be done by including one of the concepts: \"input\", \"output\" or \"internal\""
+                + "\nalong with the list of signals of those types."
+                + "\nE.g input [a, b] <> output [c] <> internal [x]", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+    }
+
 }

--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsToolException.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsToolException.java
@@ -35,7 +35,7 @@ public class ConceptsToolException extends Exception {
             } else {
                 String output = new String(result.getReturnValue().getOutput());
                 if (!output.startsWith(".model out")) {
-                    if (output.contains("following signals have not been declared as a type")) {
+                    if (output.contains("Error. The following signals are not declared")) {
                         signalTypeNotDeclared(output);
                     } else {
                         cannotTranslateConceptsError(output);

--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsToolException.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsToolException.java
@@ -35,8 +35,17 @@ public class ConceptsToolException extends Exception {
             } else {
                 String output = new String(result.getReturnValue().getOutput());
                 if (!output.startsWith(".model out")) {
-                    if (output.contains("Error. The following signals are not declared")) {
-                        signalTypeNotDeclared(output);
+                    if (output.contains("Error.")) {
+                        System.out.println(LogUtils.PREFIX_STDERR + output);
+                        if (output.contains("The following signals are not declared as input, output or internal")) {
+                            signalTypeNotDeclared();
+                        }
+                        if (output.contains("The following signals have inconsistent inital states")) {
+                            inconsistentStates();
+                        }
+                        if (output.contains("The following signals have undefined initial states")) {
+                            undefinedStates();
+                        }
                     } else {
                         cannotTranslateConceptsError(output);
                     }
@@ -76,15 +85,29 @@ public class ConceptsToolException extends Exception {
                 + "\nSee console window for error information", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
     }
 
-    private void signalTypeNotDeclared(String output) {
-
-        System.out.println(LogUtils.PREFIX_STDERR + output);
-
+    private void signalTypeNotDeclared() {
         JOptionPane.showMessageDialog(mainWindow, ""
-                + "One or more signals have not had their type declared. A list of these can be found in the console window.\n"
+                + "One or more signals have not had their type declared. \n"
+                + "A list of these can be found in the console window.\n"
                 + "This can be done by including one of the concepts: \"input\", \"output\" or \"internal\""
                 + "\nalong with the list of signals of those types."
                 + "\nE.g input [a, b] <> output [c] <> internal [x]", "Concept translation failed", JOptionPane.ERROR_MESSAGE);
     }
 
+    private void inconsistentStates() {
+        JOptionPane.showMessageDialog(mainWindow, ""
+                + "One or more signals has inconsistent initial states.\n"
+                + "A list of these signals can be found in the console window.\n"
+                + "This occurs when a signal has their initial state declared both high (1) and low (0).",
+                "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+    }
+
+    private void undefinedStates() {
+        JOptionPane.showMessageDialog(mainWindow, ""
+                + "One or more signals has undefined initial states.\n"
+                + "A list of these signals can be found in the console window.\n"
+                + "These signals have no initial state declared. Initial states can be set using any of the following concepts:\n"
+                + "\"initialise a False <> initialise b True <> initials [x, y, z] True <> initials [p, q] False",
+                "Concept translation failed", JOptionPane.ERROR_MESSAGE);
+    }
 }

--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsToolException.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsToolException.java
@@ -107,7 +107,7 @@ public class ConceptsToolException extends Exception {
                 + "One or more signals has undefined initial states.\n"
                 + "A list of these signals can be found in the console window.\n"
                 + "These signals have no initial state declared. Initial states can be set using any of the following concepts:\n"
-                + "\"initialise a False <> initialise b True <> initials [x, y, z] True <> initials [p, q] False",
+                + "\"initialise a False <> initialise b True <> initialise0 [x, y, z] <> initialise1 [p, q]",
                 "Concept translation failed", JOptionPane.ERROR_MESSAGE);
     }
 }

--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsWriterDialog.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsWriterDialog.java
@@ -111,8 +111,6 @@ public class ConceptsWriterDialog extends JDialog {
     }
 
     private void createFileBtnPanel() {
-        JLabel fileLabel = new JLabel("File options: ");
-
         JButton openFileBtn = GUI.createDialogButton("Open file");
         JButton saveFileBtn = GUI.createDialogButton("Save to file");
         JButton resetBtn = GUI.createDialogButton("Reset to default");
@@ -189,7 +187,6 @@ public class ConceptsWriterDialog extends JDialog {
 
         });
 
-        btnPanel.add(fileLabel, BorderLayout.NORTH);
         btnPanel.add(fileBtnPanel, BorderLayout.WEST);
     }
 

--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsWritingTool.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsWritingTool.java
@@ -2,15 +2,14 @@ package org.workcraft.plugins.stg.concepts;
 
 import java.io.File;
 
+import org.workcraft.ConversionTool;
 import org.workcraft.Framework;
-import org.workcraft.Tool;
 import org.workcraft.plugins.stg.VisualStg;
 import org.workcraft.util.FileUtils;
 import org.workcraft.workspace.WorkspaceEntry;
 
-public class ConceptsWritingTool implements Tool {
+public class ConceptsWritingTool extends ConversionTool {
 
-    @Override
     public boolean isApplicableTo(WorkspaceEntry we) {
         if (we.getModelEntry() == null) return false;
         if (we.getModelEntry().getVisualModel() instanceof VisualStg) return true;
@@ -18,16 +17,14 @@ public class ConceptsWritingTool implements Tool {
     }
 
     @Override
-    public String getSection() {
-        return "! Concepts";
+    public Position getPosition() {
+        return Position.BOTTOM;
     }
 
-    @Override
     public String getDisplayName() {
-        return "Write concepts...";
+        return "Translate concepts...";
     }
 
-    @Override
     public void run(WorkspaceEntry we) {
         ConceptsWriterDialog dialog = new ConceptsWriterDialog();
         dialog.setVisible(true);


### PR DESCRIPTION
An update to the concepts tool now allows declaration of signal types. In the event one or more signals is not type declared, it will throw an error, and list the affected signals.

@danilovesky: This will need the latest version of the concepts tool when it has been merged into that repo. I will let you know when that is done.
