### PR TITLE
Fixed some macOS issues.

### DIFF
--- a/WorkcraftCore/src/org/workcraft/Console.java
+++ b/WorkcraftCore/src/org/workcraft/Console.java
@@ -46,6 +46,7 @@ public class Console {
         //Allows menu bar of OS X to be used instead of being in the Workcraft main window.
         if (DesktopApi.getOs().isMac()) {
             System.setProperty("apple.laf.useScreenMenuBar", "true");
+            System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS");
         }
     }
 

--- a/WorkcraftCore/src/org/workcraft/gui/LookAndFeelHelper.java
+++ b/WorkcraftCore/src/org/workcraft/gui/LookAndFeelHelper.java
@@ -26,8 +26,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.swing.InputMap;
+import javax.swing.KeyStroke;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.text.DefaultEditorKit;
 
 import org.jvnet.substance.SubstanceLookAndFeel;
 import org.jvnet.substance.api.SubstanceConstants.TabContentPaneBorderKind;
@@ -56,6 +58,10 @@ public class LookAndFeelHelper {
         InputMap textAreaInputMap = (InputMap) UIManager.get("TextArea.focusInputMap");
         setLookAndFeel(laf);
         if (DesktopApi.getOs().isMac()) {
+            textFieldInputMap.put(KeyStroke.getKeyStroke("UP"), DefaultEditorKit.upAction);
+            textAreaInputMap.put(KeyStroke.getKeyStroke("UP"), DefaultEditorKit.upAction);
+            textFieldInputMap.put(KeyStroke.getKeyStroke("DOWN"), DefaultEditorKit.downAction);
+            textAreaInputMap.put(KeyStroke.getKeyStroke("DOWN"), DefaultEditorKit.downAction);
             UIManager.put("TextField.focusInputMap", textFieldInputMap);
             UIManager.put("TextArea.focusInputMap", textAreaInputMap);
         }


### PR DESCRIPTION
Up/Down arrow keys will now correctly navigate in text areas and fields in macOS
`cmd-Q` will now correctly exit workcraft, performing the necessary shut down procedures.

I have tested on Windows and these changes do not affect at least the Windows build of Workcraft.
