### PR TITLE
Right-click (two-finger-click) should now work on macOS

### DIFF
--- a/WorkcraftCore/src/org/workcraft/gui/graph/GraphEditorPanelMouseListener.java
+++ b/WorkcraftCore/src/org/workcraft/gui/graph/GraphEditorPanelMouseListener.java
@@ -92,9 +92,7 @@ class GraphEditorPanelMouseListener implements MouseMotionListener, MouseListene
             final MainWindow mainWindow = framework.getMainWindow();
             mainWindow.requestFocus(editor);
         }
-        if (!isPanCombo(e)) {
-            toolProvider.getSelectedTool().mouseClicked(adaptEvent(e));
-        }
+        toolProvider.getSelectedTool().mouseClicked(adaptEvent(e));
     }
 
     @Override


### PR DESCRIPTION
Fixed #605