### PR TITLE
Some minor clean ups and fixes

### DIFF
--- a/CpogPlugin/src/org/workcraft/plugins/cpog/tools/CpogParsingTool.java
+++ b/CpogPlugin/src/org/workcraft/plugins/cpog/tools/CpogParsingTool.java
@@ -682,27 +682,27 @@ public class CpogParsingTool {
             added = false;
             if (text.contains(" " + k + " ")) {
                 if (k.startsWith("[")) {
-                    text = text.replaceAll(" " + k + " ", " (" + refMap.get(k).getNormalForm() + ") ");
+                    text = text.replace(" " + k + " ", " (" + refMap.get(k).getNormalForm() + ") ");
                     added = true;
                 } else {
-                    text = text.replaceAll(" " + k + " ", " (" + refMap.get(k).getNormalForm() + ") ");
+                    text = text.replace(" " + k + " ", " (" + refMap.get(k).getNormalForm() + ") ");
                     added = true;
                 }
             }
             if (text.contains("]" + k + " ")) {
-                text = text.replaceAll("]" + k + " ", "](" + refMap.get(k).getNormalForm() + ") ");
+                text = text.replace("]" + k + " ", "](" + refMap.get(k).getNormalForm() + ") ");
                 added = true;
             }
             if (text.contains("(" + k + ")")) {
-                text = text.replaceAll("\\(" + k + "\\)", "\\(" + refMap.get(k).getNormalForm() + "\\)");
+                text = text.replace("(" + k + ")", "(" + refMap.get(k).getNormalForm() + ")");
                 added = true;
             }
             if (text.contains("(" + k + " ")) {
-                text = text.replaceAll("\\(" + k + " ", "\\(\\(" + refMap.get(k).getNormalForm() + "\\) ");
+                text = text.replace("(" + k + " ", "((" + refMap.get(k).getNormalForm() + ") ");
                 added = true;
             }
             if (text.contains(" " + k + ")")) {
-                text = text.replaceAll(" " + k + "\\)", " \\(" + refMap.get(k).getNormalForm() + "\\)\\)");
+                text = text.replace(" " + k + ")", " (" + refMap.get(k).getNormalForm() + "))");
                 added = true;
             }
             if (text.endsWith(" " + k)) {
@@ -714,7 +714,7 @@ public class CpogParsingTool {
                 added = true;
             }
             if (text.endsWith(" " + k + ")")) {
-                text = text.replace(" " + k + "\\)", " (" + refMap.get(k).getNormalForm() + "\\)\\)");
+                text = text.replace(" " + k + ")", " (" + refMap.get(k).getNormalForm() + "))");
                 added = true;
             }
 

--- a/StgPlugin/src/org/workcraft/plugins/stg/StgSettings.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/StgSettings.java
@@ -25,7 +25,7 @@ public class StgSettings implements Settings {
     private static final String defaultLowLevelSuffix = "_LOW";
     private static final String defaultHighLevelSuffix = "_HIGH";
     private static final Boolean defaultGroupSignalConversion = false;
-    private static final String defaultConceptsFolderLocation = DesktopApi.getOs().isWindows() ? "tools\\concepts\\" : "tools/concepts/";
+    private static final String defaultConceptsFolderLocation = DesktopApi.getOs().isWindows() ? "tools\\plato\\" : "tools/plato/";
 
     private static Integer densityMapLevelLimit = defaultDensityMapLevelLimit;
     private static String lowLevelSuffix = defaultLowLevelSuffix;


### PR DESCRIPTION
* `CpogParsingTool` now uses `replace` instead of `replaceAll`

* `plato` is now referred to instead of `concepts` for the concepts translation tool.

I have not renamed any of the files for `plato`, as I am not sure how necessary it is, and `plato` doesn't quite fit for some of them, as the names refer to translation. If you want I am happy to rename them now, but updating the location from `tools/concepts/` to `tools/plato/` is all that is necessary for the tool to work currently. If not, I will do it at some point in the future when I add features to the tool, which will need changes to Workcraft.