### PR TITLE
Added include dialog to concepts translation dialog.

### DIFF
--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsIncludesDialog.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsIncludesDialog.java
@@ -1,0 +1,111 @@
+package org.workcraft.plugins.stg.concepts;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.filechooser.FileNameExtensionFilter;
+
+import org.workcraft.util.GUI;
+
+@SuppressWarnings("serial")
+public class ConceptsIncludesDialog extends JDialog {
+
+    private final JPanel content, btnPanel;
+    private final File lastDirUsed;
+    private static JList<String> includeList;
+    private final DefaultListModel<String> includeListModel;
+
+    public ConceptsIncludesDialog(ConceptsWriterDialog parent, File lastDirUsed,
+            DefaultListModel<String> includeListModel) {
+        super(parent, "Include concept files", ModalityType.APPLICATION_MODAL);
+
+        this.lastDirUsed = lastDirUsed;
+        this.includeListModel = includeListModel;
+
+        content = new JPanel();
+        content.setLayout(new BorderLayout());
+
+        btnPanel = new JPanel();
+
+        createListPanel();
+        createBtnPanel();
+
+        content.add(btnPanel, BorderLayout.SOUTH);
+
+        setContentPane(content);
+        setMinimumSize(new Dimension(500, 500));
+        this.setLocationRelativeTo(parent);
+    }
+
+    private void createListPanel() {
+        includeList = new JList<String>(includeListModel);
+
+        content.add(includeList, BorderLayout.CENTER);
+    }
+
+    private void createBtnPanel() {
+        JButton addBtn = GUI.createDialogButton("Add");
+        JButton removeBtn = GUI.createDialogButton("Remove");
+        JButton okBtn = GUI.createDialogButton("OK");
+
+        btnPanel.add(addBtn);
+        btnPanel.add(removeBtn);
+        btnPanel.add(okBtn);
+
+        addBtn.addActionListener(new ActionListener() {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                JFileChooser chooser = new JFileChooser();
+                chooser.setFileFilter(new FileNameExtensionFilter("Haskell/Concept file (.hs)", "hs"));
+                chooser.setCurrentDirectory(lastDirUsed);
+                if (chooser.showOpenDialog(null) == JFileChooser.APPROVE_OPTION) {
+                    File f = chooser.getSelectedFile();
+                    try {
+                        if (!f.exists()) {
+                            throw new FileNotFoundException();
+                        }
+                        includeListModel.addElement(f.getAbsolutePath());
+                        // includeList.setListData(includeListModel);
+                    } catch (FileNotFoundException e1) {
+                        JOptionPane.showMessageDialog(null, e1.getMessage(), "File not found error",
+                                JOptionPane.ERROR_MESSAGE);
+                    }
+
+                }
+            }
+        });
+
+        removeBtn.addActionListener(new ActionListener() {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (!includeList.isSelectionEmpty()) {
+                    includeListModel.removeElement(includeList.getSelectedValue());
+                }
+            }
+
+        });
+
+        okBtn.addActionListener(new ActionListener() {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setVisible(false);
+            }
+
+        });
+    }
+
+}

--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsWriterDialog.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/ConceptsWriterDialog.java
@@ -14,6 +14,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Scanner;
 
+import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
@@ -40,6 +41,7 @@ public class ConceptsWriterDialog extends JDialog {
     private JTextArea conceptsText;
     private JCheckBox dotLayoutCheckBox;
     private boolean changed = false, translate = false;
+    private static DefaultListModel<String> includeList = new DefaultListModel<String>();
 
     public ConceptsWriterDialog() {
         super(Framework.getInstance().getMainWindow(), "Write and translate Concepts", ModalityType.APPLICATION_MODAL);
@@ -61,8 +63,7 @@ public class ConceptsWriterDialog extends JDialog {
             public void actionPerformed(ActionEvent e) {
                 setVisible(false);
             }
-        }, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
-                JComponent.WHEN_IN_FOCUSED_WINDOW);
+        }, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), JComponent.WHEN_IN_FOCUSED_WINDOW);
 
         setContentPane(content);
         setMinimumSize(new Dimension(1000, 500));
@@ -96,12 +97,12 @@ public class ConceptsWriterDialog extends JDialog {
 
             @Override
             public void keyPressed(KeyEvent e) {
-                //Do nothing
+                // Do nothing
             }
 
             @Override
             public void keyReleased(KeyEvent e) {
-                //Do nothing
+                // Do nothing
             }
 
         });
@@ -115,11 +116,13 @@ public class ConceptsWriterDialog extends JDialog {
         JButton openFileBtn = GUI.createDialogButton("Open file");
         JButton saveFileBtn = GUI.createDialogButton("Save to file");
         JButton resetBtn = GUI.createDialogButton("Reset to default");
+        JButton includeBtn = GUI.createDialogButton("Included files");
         dotLayoutCheckBox = new JCheckBox("Use dot layout");
         JPanel fileBtnPanel = new JPanel();
         fileBtnPanel.add(openFileBtn);
         fileBtnPanel.add(saveFileBtn);
         fileBtnPanel.add(resetBtn);
+        fileBtnPanel.add(includeBtn);
         fileBtnPanel.add(dotLayoutCheckBox);
 
         openFileBtn.addActionListener(new ActionListener() {
@@ -139,8 +142,8 @@ public class ConceptsWriterDialog extends JDialog {
                         conceptsText.setText(readFile(f));
                         updateLastDirUsed();
                     } catch (FileNotFoundException e1) {
-                        JOptionPane.showMessageDialog(null, e1.getMessage(),
-                                "File not found error", JOptionPane.ERROR_MESSAGE);
+                        JOptionPane.showMessageDialog(null, e1.getMessage(), "File not found error",
+                                JOptionPane.ERROR_MESSAGE);
                     }
 
                 }
@@ -183,6 +186,17 @@ public class ConceptsWriterDialog extends JDialog {
                 conceptsText.setText(getDefaultText());
                 lastFileUsed = null;
                 changed = false;
+            }
+
+        });
+
+        final ConceptsIncludesDialog dialog = new ConceptsIncludesDialog(this, lastDirUsed, includeList);
+
+        includeBtn.addActionListener(new ActionListener() {
+
+            @Override
+            public void actionPerformed(ActionEvent arg0) {
+                dialog.setVisible(true);
             }
 
         });
@@ -233,12 +247,7 @@ public class ConceptsWriterDialog extends JDialog {
     }
 
     private String getDefaultText() {
-        return "module Concept where\n"
-                + "\n"
-                + "import Tuura.Concept.STG\n"
-                + "\n"
-                + "circuit a b c = \n"
-                + "  where";
+        return "module Concept where\n" + "\n" + "import Tuura.Concept.STG\n" + "\n" + "circuit a b c = \n" + "  where";
     }
 
     private String readFile(File file) throws FileNotFoundException {
@@ -280,6 +289,10 @@ public class ConceptsWriterDialog extends JDialog {
 
     public boolean getDotLayoutState() {
         return dotLayoutCheckBox.isSelected();
+    }
+
+    public Object[] getIncludeList() {
+        return includeList.toArray();
     }
 
 }

--- a/StgPlugin/src/org/workcraft/plugins/stg/concepts/TranslateConceptConversionCommand.java
+++ b/StgPlugin/src/org/workcraft/plugins/stg/concepts/TranslateConceptConversionCommand.java
@@ -41,7 +41,7 @@ public class TranslateConceptConversionCommand extends AbstractConversionCommand
             final TaskManager taskManager = framework.getTaskManager();
             File inputFile = dialog.getFile();
             dotLayout = dialog.getDotLayoutState();
-            ConceptsTask task = new ConceptsTask(inputFile);
+            ConceptsTask task = new ConceptsTask(inputFile, dialog.getIncludeList());
             String name = FileUtils.getFileNameWithoutExtension(inputFile);
             ConceptsResultHandler resultHandler = new ConceptsResultHandler(this, name, we);
             taskManager.queue(task, "Translating concepts", resultHandler);


### PR DESCRIPTION
Concept files can now import other concept files, allowing reuse of concepts. Include has been implemented in Plato, and this PR adds a dialog to select all files to be imported by the tool when translating.