### PR TITLE
Fixes for maximised tabs and editor focus

### DIFF
--- a/MpsatVerificationPlugin/src/org/workcraft/plugins/mpsat/gui/MpsatSolutionPanel.java
+++ b/MpsatVerificationPlugin/src/org/workcraft/plugins/mpsat/gui/MpsatSolutionPanel.java
@@ -2,7 +2,6 @@ package org.workcraft.plugins.mpsat.gui;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -75,20 +74,11 @@ public class MpsatSolutionPanel extends JPanel {
             public void actionPerformed(ActionEvent e) {
                 final Framework framework = Framework.getInstance();
                 final MainWindow mainWindow = framework.getMainWindow();
-                GraphEditorPanel currentEditor = mainWindow.getCurrentEditor();
-                if (currentEditor == null || currentEditor.getWorkspaceEntry() != we) {
-                    final List<GraphEditorPanel> editors = mainWindow.getEditors(we);
-                    if (editors.size() > 0) {
-                        currentEditor = editors.get(0);
-                        mainWindow.requestFocus(currentEditor);
-                    } else {
-                        currentEditor = mainWindow.createEditorWindow(we);
-                    }
-                }
-                final ToolboxPanel toolbox = currentEditor.getToolBox();
+                GraphEditorPanel editor = mainWindow.getEditor(we);
+                final ToolboxPanel toolbox = editor.getToolBox();
                 final SimulationTool tool = toolbox.getToolInstance(SimulationTool.class);
                 toolbox.selectTool(tool);
-                tool.setTrace(solution.getMainTrace(), solution.getBranchTrace(), currentEditor);
+                tool.setTrace(solution.getMainTrace(), solution.getBranchTrace(), editor);
                 String comment = solution.getComment();
                 if ((comment != null) && !comment.isEmpty()) {
                     comment = comment.replaceAll("\\<.*?>", "");

--- a/SonPlugin/src/org/workcraft/plugins/son/commands/ToolManager.java
+++ b/SonPlugin/src/org/workcraft/plugins/son/commands/ToolManager.java
@@ -1,7 +1,5 @@
 package org.workcraft.plugins.son.commands;
 
-import java.util.List;
-
 import org.workcraft.Framework;
 import org.workcraft.gui.MainWindow;
 import org.workcraft.gui.ToolboxPanel;
@@ -13,17 +11,8 @@ public class ToolManager {
     public static ToolboxPanel getToolboxPanel(WorkspaceEntry we) {
         final Framework framework = Framework.getInstance();
         final MainWindow mainWindow = framework.getMainWindow();
-        GraphEditorPanel currentEditor = mainWindow.getCurrentEditor();
-        if (currentEditor == null || currentEditor.getWorkspaceEntry() != we) {
-            final List<GraphEditorPanel> editors = mainWindow.getEditors(we);
-            if (editors.size() > 0) {
-                currentEditor = editors.get(0);
-                mainWindow.requestFocus(currentEditor);
-            } else {
-                currentEditor = mainWindow.createEditorWindow(we);
-            }
-        }
-        return currentEditor.getToolBox();
+        GraphEditorPanel editor = mainWindow.getEditor(we);
+        return editor.getToolBox();
     }
 
 }

--- a/WorkcraftCore/src/org/workcraft/gui/DockableWindowContentPanel.java
+++ b/WorkcraftCore/src/org/workcraft/gui/DockableWindowContentPanel.java
@@ -43,18 +43,17 @@ public class DockableWindowContentPanel extends JPanel {
 
         @Override
         public void run() {
+            final Framework framework = Framework.getInstance();
+            MainWindow mainWindow = framework.getMainWindow();
             switch (actionType) {
             case CLOSE_ACTION:
                 try {
-                    final Framework framework = Framework.getInstance();
-                    framework.getMainWindow().closeDockableWindow(windowID);
+                    mainWindow.closeDockableWindow(windowID);
                 } catch (OperationCancelledException e) {
-
                 }
                 break;
             case MAXIMIZE_ACTION:
-                final Framework framework = Framework.getInstance();
-                framework.getMainWindow().toggleDockableWindowMaximized(windowID);
+                mainWindow.toggleDockableWindowMaximized(windowID);
                 break;
             case MINIMIZE_ACTION:
                 throw new NotSupportedException();
@@ -103,7 +102,8 @@ public class DockableWindowContentPanel extends JPanel {
             int iconCount = 0;
             if ((options & MINIMIZE_BUTTON) != 0) {
                 Icon minIcon = UIManager.getIcon("InternalFrame.minimizeIcon");
-                btnMin = createHeaderButton(minIcon, new ViewAction(id, ViewAction.MINIMIZE_ACTION), mainWindow.getDefaultActionListener());
+                ViewAction minAction = new ViewAction(id, ViewAction.MINIMIZE_ACTION);
+                btnMin = createHeaderButton(minIcon, minAction, mainWindow.getDefaultActionListener());
                 btnMin.setToolTipText("Toggle minimized");
                 buttonPanel.add(btnMin);
                 iconCount++;
@@ -111,21 +111,24 @@ public class DockableWindowContentPanel extends JPanel {
 
             if ((options & MAXIMIZE_BUTTON) != 0) {
                 Icon maxIcon = UIManager.getIcon("InternalFrame.maximizeIcon");
-                btnMax = createHeaderButton(maxIcon, new ViewAction(id, ViewAction.MAXIMIZE_ACTION), mainWindow.getDefaultActionListener());
+                ViewAction maxAction = new ViewAction(id, ViewAction.MAXIMIZE_ACTION);
+                btnMax = createHeaderButton(maxIcon, maxAction, mainWindow.getDefaultActionListener());
                 buttonPanel.add(btnMax);
                 iconCount++;
             }
 
             Icon closeIcon = UIManager.getIcon("InternalFrame.closeIcon");
             if ((options & CLOSE_BUTTON) != 0) {
-                btnClose = createHeaderButton(closeIcon, new ViewAction(id, ViewAction.CLOSE_ACTION), mainWindow.getDefaultActionListener());
+                ViewAction closeAction = new ViewAction(id, ViewAction.CLOSE_ACTION);
+                btnClose = createHeaderButton(closeIcon, closeAction, mainWindow.getDefaultActionListener());
                 btnClose.setToolTipText("Close window");
                 buttonPanel.add(btnClose);
                 iconCount++;
             }
 
             if (iconCount != 0) {
-                buttonPanel.setPreferredSize(new Dimension((closeIcon.getIconWidth() + 4) * iconCount, closeIcon.getIconHeight() + 4));
+                Dimension size = new Dimension((closeIcon.getIconWidth() + 4) * iconCount, closeIcon.getIconHeight() + 4);
+                buttonPanel.setPreferredSize(size);
             }
 
             titleLabel = new JLabel(title);

--- a/WorkcraftCore/src/org/workcraft/gui/DockableWindowTabListener.java
+++ b/WorkcraftCore/src/org/workcraft/gui/DockableWindowTabListener.java
@@ -8,4 +8,6 @@ public interface DockableWindowTabListener {
     void tabSelected(JTabbedPane pane, int index);
     void tabDeselected(JTabbedPane pane, int index);
     void headerClicked();
+    void windowMaximised();
+    void windowRestored();
 }

--- a/WorkcraftCore/src/org/workcraft/gui/EditorWindowTabListener.java
+++ b/WorkcraftCore/src/org/workcraft/gui/EditorWindowTabListener.java
@@ -15,9 +15,8 @@ public class EditorWindowTabListener implements DockableWindowTabListener {
 
     @Override
     public void tabSelected(JTabbedPane tabbedPane, int tabIndex) {
-        final Framework framework = Framework.getInstance();
-        MainWindow mainWindow = framework.getMainWindow();
-        mainWindow.requestFocus(editor);
+        setNonFocusable(tabbedPane);
+        requestEditorFocus();
     }
 
     @Override
@@ -26,14 +25,36 @@ public class EditorWindowTabListener implements DockableWindowTabListener {
 
     @Override
     public void dockedStandalone() {
+        requestEditorFocus();
     }
 
     @Override
     public void dockedInTab(JTabbedPane tabbedPane, int tabIndex) {
+        setNonFocusable(tabbedPane);
+        requestEditorFocus();
     }
 
     @Override
     public void headerClicked() {
+        requestEditorFocus();
+    }
+
+    @Override
+    public void windowMaximised() {
+        requestEditorFocus();
+    }
+
+    @Override
+    public void windowRestored() {
+        requestEditorFocus();
+    }
+
+    private void setNonFocusable(JTabbedPane tabbedPane) {
+        // Set non-focusable, so that tab activation does not steal the focus form the included component.
+        tabbedPane.setFocusable(false);
+    }
+
+    private void requestEditorFocus() {
         final Framework framework = Framework.getInstance();
         MainWindow mainWindow = framework.getMainWindow();
         mainWindow.requestFocus(editor);

--- a/WorkcraftCore/src/org/workcraft/gui/graph/GraphEditorPanel.java
+++ b/WorkcraftCore/src/org/workcraft/gui/graph/GraphEditorPanel.java
@@ -72,6 +72,27 @@ public class GraphEditorPanel extends JPanel implements StateObserver, GraphEdit
     public static final String TITLE_SUFFIX_SELECTED_ELEMENTS = " selected elements";
     private static final int VIEWPORT_MARGIN = 25;
 
+    public class GraphEditorFocusListener implements FocusListener {
+        private final GraphEditorPanel editor;
+
+        public GraphEditorFocusListener(GraphEditorPanel editor) {
+            this.editor = editor;
+        }
+
+        @Override
+        public void focusGained(FocusEvent e) {
+            final Framework framework = Framework.getInstance();
+            MainWindow mainWindow = framework.getMainWindow();
+            mainWindow.requestFocus(editor);
+            repaint();
+        }
+
+        @Override
+        public void focusLost(FocusEvent e) {
+            repaint();
+        }
+    }
+
     class Resizer implements ComponentListener {
 
         @Override
@@ -90,18 +111,6 @@ public class GraphEditorPanel extends JPanel implements StateObserver, GraphEdit
 
         @Override
         public void componentShown(ComponentEvent e) {
-        }
-    }
-
-    public class GraphEditorFocusListener implements FocusListener {
-        @Override
-        public void focusGained(FocusEvent e) {
-            repaint();
-        }
-
-        @Override
-        public void focusLost(FocusEvent e) {
-            repaint();
         }
     }
 
@@ -201,14 +210,14 @@ public class GraphEditorPanel extends JPanel implements StateObserver, GraphEdit
 
         GraphEditorPanelMouseListener mouseListener = new GraphEditorPanelMouseListener(this, toolboxPanel);
         GraphEditorPanelKeyListener keyListener = new GraphEditorPanelKeyListener(this, toolboxPanel);
+        GraphEditorFocusListener focusListener = new GraphEditorFocusListener(this);
 
         addMouseMotionListener(mouseListener);
         addMouseListener(mouseListener);
         addMouseWheelListener(mouseListener);
-        addFocusListener(new GraphEditorFocusListener());
-        addComponentListener(new Resizer());
-
         addKeyListener(keyListener);
+        addFocusListener(focusListener);
+        addComponentListener(new Resizer());
 
         add(overlay, BorderLayout.CENTER);
 

--- a/WorkcraftCore/src/org/workcraft/gui/graph/GraphEditorPanelKeyListener.java
+++ b/WorkcraftCore/src/org/workcraft/gui/graph/GraphEditorPanelKeyListener.java
@@ -8,8 +8,8 @@ import org.workcraft.gui.events.GraphEditorKeyEvent;
 import org.workcraft.gui.graph.tools.GraphEditorKeyListener;
 
 class GraphEditorPanelKeyListener implements KeyListener {
-    GraphEditorPanel editor;
-    GraphEditorKeyListener forwardListener;
+    private final GraphEditorPanel editor;
+    private final GraphEditorKeyListener forwardListener;
 
     GraphEditorPanelKeyListener(GraphEditorPanel editor, GraphEditorKeyListener forwardListener) {
         this.editor = editor;

--- a/WorkcraftCore/src/org/workcraft/gui/tabs/DockableTab.java
+++ b/WorkcraftCore/src/org/workcraft/gui/tabs/DockableTab.java
@@ -41,20 +41,22 @@ public class DockableTab extends JPanel {
         label.setFocusable(false);
         label.setOpaque(false);
 
-        TabButton close = null;
+        TabButton closeButton = null;
         if ((dockableWindow.getOptions() & DockableWindowContentPanel.MAXIMIZE_BUTTON) != 0) {
-            TabButton max = new TabButton("\u2191", "Maximize window", new ViewAction(dockableWindow.getID(), ViewAction.MAXIMIZE_ACTION), actionListener);
-            buttonsPanel.add(max);
+            ViewAction viewAction = new ViewAction(dockableWindow.getID(), ViewAction.MAXIMIZE_ACTION);
+            TabButton maxButton = new TabButton("\u2191", "Maximize window", viewAction, actionListener);
+            buttonsPanel.add(maxButton);
             buttonsPanel.add(Box.createRigidArea(new Dimension(2, 0)));
         }
 
         if ((dockableWindow.getOptions() & DockableWindowContentPanel.CLOSE_BUTTON) != 0) {
-            close = new TabButton("\u00d7", "Close window", new ViewAction(dockableWindow.getID(), ViewAction.CLOSE_ACTION), actionListener);
-            buttonsPanel.add(close);
+            ViewAction viewAction = new ViewAction(dockableWindow.getID(), ViewAction.CLOSE_ACTION);
+            closeButton = new TabButton("\u00d7", "Close window", viewAction, actionListener);
+            buttonsPanel.add(closeButton);
         }
 
         Dimension x = label.getPreferredSize();
-        Dimension y = (close != null) ? close.getPreferredSize() : x;
+        Dimension y = (closeButton != null) ? closeButton.getPreferredSize() : x;
 
         this.add(label, BorderLayout.CENTER);
         this.add(buttonsPanel, BorderLayout.EAST);


### PR DESCRIPTION
  * All tabs are un-maximised on creation of a new work.
  * Tabs are made non-focusable so they do not steal focus from
the ebmedded editor.
  * Focus is set to the editor on tab selection, header click,
maximisation and size restore.

Fixes #113