### PR TITLE
Reconfigure plugins on every start

### DIFF
--- a/CircuitPlugin/test/org/workcraft/plugins/circuit/CircuitConversionCommandsTests.java
+++ b/CircuitPlugin/test/org/workcraft/plugins/circuit/CircuitConversionCommandsTests.java
@@ -27,7 +27,7 @@ public class CircuitConversionCommandsTests {
     @BeforeClass
     public static void initPlugins() {
         final Framework framework = Framework.getInstance();
-        framework.initPlugins(false);
+        framework.initPlugins();
     }
 
     @Test

--- a/CircuitPlugin/test/org/workcraft/plugins/circuit/CircuitImportExportTests.java
+++ b/CircuitPlugin/test/org/workcraft/plugins/circuit/CircuitImportExportTests.java
@@ -30,7 +30,7 @@ public class CircuitImportExportTests {
     @BeforeClass
     public static void initPlugins() {
         final Framework framework = Framework.getInstance();
-        framework.initPlugins(false);
+        framework.initPlugins();
         switch (DesktopApi.getOs()) {
         case LINUX:
             CircuitSettings.setGateLibrary("../dist-template/linux/libraries/workcraft.lib");

--- a/CircuitPlugin/test/org/workcraft/plugins/circuit/CircuitLayoutTests.java
+++ b/CircuitPlugin/test/org/workcraft/plugins/circuit/CircuitLayoutTests.java
@@ -25,7 +25,7 @@ public class CircuitLayoutTests {
     @BeforeClass
     public static void initPlugins() {
         final Framework framework = Framework.getInstance();
-        framework.initPlugins(false);
+        framework.initPlugins();
         switch (DesktopApi.getOs()) {
         case LINUX:
             CircuitSettings.setGateLibrary("../dist-template/linux/libraries/workcraft.lib");

--- a/MpsatSynthesisPlugin/test/org/workcraft/plugins/mpsat/MpsatSynthesisCommandsTests.java
+++ b/MpsatSynthesisPlugin/test/org/workcraft/plugins/mpsat/MpsatSynthesisCommandsTests.java
@@ -27,7 +27,7 @@ public class MpsatSynthesisCommandsTests {
     @BeforeClass
     public static void initPlugins() {
         final Framework framework = Framework.getInstance();
-        framework.initPlugins(false);
+        framework.initPlugins();
         switch (DesktopApi.getOs()) {
         case LINUX:
             PunfSettings.setCommand("../dist-template/linux/tools/UnfoldingTools/punf");

--- a/PetriPlugin/test/org/workcraft/plugins/petri/SaveLoadTests.java
+++ b/PetriPlugin/test/org/workcraft/plugins/petri/SaveLoadTests.java
@@ -46,7 +46,7 @@ public class SaveLoadTests {
     //@Test
     public void testMathModelLoad() throws Exception {
         Framework framework = Framework.getInstance();
-        framework.getPluginManager().reconfigureManifest(false);
+        framework.getPluginManager().initPlugins();
 
         final CompatibilityManager compatibilityManager = framework.getCompatibilityManager();
         ByteArrayInputStream bis = compatibilityManager.process(new Base16Reader(testDataMathModel), null);
@@ -61,7 +61,7 @@ public class SaveLoadTests {
     //@Test
     public void testVisualModelLoad() throws Exception {
         Framework framework = Framework.getInstance();
-        framework.getPluginManager().reconfigureManifest(false);
+        framework.getPluginManager().initPlugins();
 
         final CompatibilityManager compatibilityManager = framework.getCompatibilityManager();
         ByteArrayInputStream bis = compatibilityManager.process(new Base16Reader(testDataVisualModel), null);
@@ -90,7 +90,7 @@ public class SaveLoadTests {
     private void ensureSampleUpToDate(String sampleVarName, Model model, String currentValue) throws SerialisationException, Exception {
         Framework framework = Framework.getInstance();
         PluginManager pm = framework.getPluginManager();
-        pm.reconfigureManifest(false);
+        pm.initPlugins();
 
         StringWriter writer = new StringWriter();
         framework.saveModel(new ModelEntry(new PetriNetDescriptor(), model), new Base16Writer(writer));

--- a/PetrifyPlugin/test/org/workcraft/plugins/petrify/PetrifyConversionCommandsTests.java
+++ b/PetrifyPlugin/test/org/workcraft/plugins/petrify/PetrifyConversionCommandsTests.java
@@ -23,7 +23,7 @@ public class PetrifyConversionCommandsTests {
     @BeforeClass
     public static void initPlugins() {
         final Framework framework = Framework.getInstance();
-        framework.initPlugins(false);
+        framework.initPlugins();
         switch (DesktopApi.getOs()) {
         case LINUX:
             PetrifySettings.setCommand("../dist-template/linux/tools/PetrifyTools/petrify");

--- a/PetrifyPlugin/test/org/workcraft/plugins/petrify/PetrifySynthesisCommandsTests.java
+++ b/PetrifyPlugin/test/org/workcraft/plugins/petrify/PetrifySynthesisCommandsTests.java
@@ -26,7 +26,7 @@ public class PetrifySynthesisCommandsTests {
     @BeforeClass
     public static void initPlugins() {
         final Framework framework = Framework.getInstance();
-        framework.initPlugins(false);
+        framework.initPlugins();
         switch (DesktopApi.getOs()) {
         case LINUX:
             PetrifySettings.setCommand("../dist-template/linux/tools/PetrifyTools/petrify");

--- a/StgPlugin/test/org/workcraft/plugins/stg/commands/CommandsTests.java
+++ b/StgPlugin/test/org/workcraft/plugins/stg/commands/CommandsTests.java
@@ -28,7 +28,7 @@ public class CommandsTests {
     @BeforeClass
     public static void initPlugins() {
         final Framework framework = Framework.getInstance();
-        framework.initPlugins(false);
+        framework.initPlugins();
     }
 
     @Test

--- a/WorkcraftCore/src/org/workcraft/Console.java
+++ b/WorkcraftCore/src/org/workcraft/Console.java
@@ -67,17 +67,17 @@ public class Console {
         System.out.println();
 
         BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
-        // NOTE: JavaScript needs to be initilised before GUI
+        // NOTE: JavaScript needs to be initialised before GUI.
         framework.initJavaScript();
         // NOTE: Plugins need to be loaded before GUI (because of assigning PropertyProviders)
-        framework.initPlugins(true);
-        // NOTE: Config needs to be loaded before GUI
+        // and before config (because of plugin-specific settings).
+        framework.initPlugins();
+        // NOTE: Config needs to be loaded before GUI.
         framework.loadConfig();
         if (startGUI) {
             framework.startGUI();
         }
-
-        //LogUtils.logMessageLine("Running startup scripts...");
+        // NOTE: Scripts should run after JavaScript, plugins, config anf GUI.
         try {
             framework.execJavaScript(FileUtils.readAllTextFromSystemResource("scripts/functions.js"));
             framework.execJavaScript(FileUtils.readAllTextFromSystemResource("scripts/startup.js"));

--- a/WorkcraftCore/src/org/workcraft/Framework.java
+++ b/WorkcraftCore/src/org/workcraft/Framework.java
@@ -39,7 +39,6 @@ import org.workcraft.dom.VisualModelDescriptor;
 import org.workcraft.dom.math.MathModel;
 import org.workcraft.dom.visual.VisualModel;
 import org.workcraft.exceptions.DeserialisationException;
-import org.workcraft.exceptions.FormatException;
 import org.workcraft.exceptions.LayoutException;
 import org.workcraft.exceptions.ModelValidationException;
 import org.workcraft.exceptions.OperationCancelledException;
@@ -284,13 +283,13 @@ public final class Framework {
         return instance;
     }
 
-    private void loadConfigPlugins() {
+    private void loadPluginsSettings() {
         for (PluginInfo<? extends Settings> info : pluginManager.getPlugins(Settings.class)) {
             info.getSingleton().load(config);
         }
     }
 
-    private void saveConfigPlugins() {
+    private void savePluginsSettings() {
         for (PluginInfo<? extends Settings> info : pluginManager.getPlugins(Settings.class)) {
             info.getSingleton().save(config);
         }
@@ -298,18 +297,18 @@ public final class Framework {
 
     public void resetConfig() {
         config = new Config();
-        loadConfigPlugins();
+        loadPluginsSettings();
     }
 
     public void loadConfig() {
         File file = new File(CONFIG_FILE_PATH);
         LogUtils.logMessageLine("Loading global preferences from " + file.getAbsolutePath());
         config.load(file);
-        loadConfigPlugins();
+        loadPluginsSettings();
     }
 
     public void saveConfig() {
-        saveConfigPlugins();
+        savePluginsSettings();
         File file = new File(CONFIG_FILE_PATH);
         LogUtils.logMessageLine("Saving global preferences to " + file.getAbsolutePath());
         config.save(file);
@@ -323,7 +322,7 @@ public final class Framework {
     public void setConfigVar(String key, String value) {
         setConfigCoreVar(key, value);
         // For consistency, update plugin settings.
-        loadConfigPlugins();
+        loadPluginsSettings();
     }
 
     public String getConfigCoreVar(String key) {
@@ -333,12 +332,12 @@ public final class Framework {
 
     public String getConfigVar(String key) {
         // For consistency, flush plugin settings.
-        saveConfigPlugins();
+        savePluginsSettings();
         return getConfigCoreVar(key);
     }
 
     public void initJavaScript() {
-        LogUtils.logMessageLine("Initialising javascript...");
+        LogUtils.logMessageLine("Initialising JavaScript...");
         contextFactory.call(new ContextAction() {
             @Override
             public Object run(Context cx) {
@@ -935,14 +934,10 @@ public final class Framework {
         }
     }
 
-    public void initPlugins(boolean load) {
+    public void initPlugins() {
         try {
-            if (load) {
-                pluginManager.loadManifest();
-            } else {
-                pluginManager.reconfigureManifest(false);
-            }
-        } catch (IOException | FormatException | PluginInstantiationException e) {
+            pluginManager.initPlugins();
+        } catch (PluginInstantiationException e) {
             e.printStackTrace();
         }
     }

--- a/WorkcraftCore/src/org/workcraft/PluginManager.java
+++ b/WorkcraftCore/src/org/workcraft/PluginManager.java
@@ -1,27 +1,17 @@
 package org.workcraft;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.workcraft.dom.ModelDescriptor;
-import org.workcraft.exceptions.FormatException;
 import org.workcraft.exceptions.PluginInstantiationException;
 import org.workcraft.plugins.PluginInfo;
 import org.workcraft.util.ConstructorParametersMatcher;
 import org.workcraft.util.ListMap;
 import org.workcraft.util.LogUtils;
-import org.workcraft.util.XmlUtil;
 
 public class PluginManager implements PluginProvider {
     public static final String VERSION_STAMP = "d971444cbd86148695f3427118632aca";
@@ -30,12 +20,11 @@ public class PluginManager implements PluginProvider {
 
     public static class PluginInstanceHolder<T> implements PluginInfo<T> {
         private final Initialiser<? extends T> initialiser;
+        private T instance;
 
         public PluginInstanceHolder(Initialiser<? extends T> initialiser) {
             this.initialiser = initialiser;
         }
-
-        T instance;
 
         @Override
         public T newInstance() {
@@ -48,75 +37,6 @@ public class PluginManager implements PluginProvider {
                 instance = newInstance();
             }
             return instance;
-        }
-    }
-
-    public void loadManifest() throws IOException, FormatException, PluginInstantiationException {
-        File file = new File(Framework.PLUGINS_FILE_PATH);
-        LogUtils.logMessageLine("Loading plugins configuration from " + file.getAbsolutePath());
-        loadManifest(file);
-    }
-
-    public boolean tryLoadManifest(File file) {
-        if (!file.exists()) {
-            LogUtils.logMessageLine("Plugin manifest '" + file.getAbsolutePath() + "' does not exist, plugins will be reconfigured.");
-            return false;
-        }
-
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        Document doc;
-        DocumentBuilder db;
-        try {
-            db = dbf.newDocumentBuilder();
-            doc = db.parse(file);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return false;
-        }
-
-        Element xmlroot = doc.getDocumentElement();
-        if (!xmlroot.getNodeName().equals("workcraft-plugins")) {
-            LogUtils.logWarningLine("Bad plugin manifest: root tag should be 'workcraft-plugins'.");
-            return false;
-        }
-
-        final Element versionElement = XmlUtil.getChildElement("version", xmlroot);
-        if (versionElement == null || !XmlUtil.readStringAttr(versionElement, "value").equals(VERSION_STAMP)) {
-            LogUtils.logWarningLine("Old plugin manifest version detected, plugins will be reconfigured.");
-            return false;
-        }
-
-        plugins.clear();
-        for (Element pluginElement : XmlUtil.getChildElements("plugin", xmlroot)) {
-            LegacyPluginInfo info = new LegacyPluginInfo(pluginElement);
-            for (String interfaceName : info.getInterfaces()) {
-                try {
-                    plugins.put(Class.forName(interfaceName), new PluginInstanceHolder<Object>(info));
-                } catch (ClassNotFoundException e) {
-                    String className = info.getClassName();
-                    LogUtils.logWarningLine("Class '" + className + "' implements unknown interface '"
-                            + interfaceName + "', skipping interface.");
-                }
-            }
-        }
-        return true;
-    }
-
-    public void loadManifest(File file) throws IOException, FormatException, PluginInstantiationException {
-        boolean needsReconfigure = false;
-        if (!tryLoadManifest(file)) {
-            needsReconfigure = true;
-        } else {
-            if (!initModules()) {
-                LogUtils.logWarningLine("Problems initialising modules, plugins will be reconfigured.");
-                needsReconfigure = true;
-            } else if (getPlugins(ModelDescriptor.class).isEmpty()) {
-                LogUtils.logWarningLine("No graph models loaded, plugins will be reconfigured.");
-                needsReconfigure = true;
-            }
-        }
-        if (needsReconfigure) {
-            reconfigureManifest(true);
         }
     }
 
@@ -140,57 +60,25 @@ public class PluginManager implements PluginProvider {
         return result;
     }
 
-    public static void saveManifest(List<LegacyPluginInfo> plugins) throws IOException {
-        File file = new File(Framework.PLUGINS_FILE_PATH);
-        LogUtils.logMessageLine("Saving plugins configuration to " + file.getAbsolutePath());
-        saveManifest(file, plugins);
-    }
-
-    public static void saveManifest(File file, List<LegacyPluginInfo> plugins) throws IOException {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        Document doc;
-        DocumentBuilder db;
-        try {
-            db = dbf.newDocumentBuilder();
-            doc = db.newDocument();
-        } catch (ParserConfigurationException e) {
-            System.err.println(e.getMessage());
-            return;
-        }
-
-        Element root = doc.createElement("workcraft-plugins");
-        doc.appendChild(root);
-        root = doc.getDocumentElement();
-
-        for (LegacyPluginInfo info : plugins) {
-            Element e = doc.createElement("plugin");
-            info.toXml(e);
-            root.appendChild(e);
-        }
-
-        final Element versionElement = doc.createElement("version");
-        versionElement.setAttribute("value", VERSION_STAMP);
-        root.appendChild(versionElement);
-
-        XmlUtil.saveDocument(doc, file);
-    }
-
     private void processLegacyPlugin(Class<?> cls, LegacyPluginInfo info) throws PluginInstantiationException {
         for (String interfaceName : info.getInterfaces()) {
             try {
-                plugins.put(Class.forName(interfaceName), new PluginInstanceHolder<Object>(info));
+                PluginInstanceHolder<Object> pih = new PluginInstanceHolder<Object>(info);
+                plugins.put(Class.forName(interfaceName), pih);
             } catch (ClassNotFoundException e) {
-                LogUtils.logWarningLine("Class '" + info.getClassName() + "' implements unknown interface '"
-                        + interfaceName + "', skipping interface.");
+                String className = info.getClassName();
+                LogUtils.logWarningLine("Class '" + className + "' implements unknown interface '" + interfaceName + "'. Skipping.");
             }
         }
     }
 
-    public void reconfigureManifest(boolean save) throws PluginInstantiationException {
-        LogUtils.logMessageLine("Reconfiguring plugins...");
+    public void initPlugins() throws PluginInstantiationException {
+        LogUtils.logMessageLine("Initialising plugins...");
         plugins.clear();
 
-        String[] classPathLocations = System.getProperty("java.class.path").split(System.getProperty("path.separator"));
+        String classPass = System.getProperty("java.class.path");
+        String pathSeparator = System.getProperty("path.separator");
+        String[] classPathLocations = classPass.split(pathSeparator);
 
         List<Class<?>> classes = new ArrayList<>();
         ArrayList<LegacyPluginInfo> pluginInfos = new ArrayList<>();
@@ -199,7 +87,6 @@ public class PluginManager implements PluginProvider {
             LogUtils.logMessageLine("  Processing class path entry: " + s);
             classes.addAll(PluginFinder.search(new File(s)));
         }
-
         LogUtils.logMessageLine("" + classes.size() + " plugin(s) found.");
 
         for (Class<?> cls : classes) {
@@ -208,13 +95,6 @@ public class PluginManager implements PluginProvider {
             processLegacyPlugin(cls, info);
         }
 
-        if (save) {
-            try {
-                saveManifest(pluginInfos);
-            } catch (IOException e) {
-                System.err.println(e.getMessage());
-            }
-        }
         initModules();
     }
 

--- a/WorkcraftCore/src/org/workcraft/gui/MainMenu.java
+++ b/WorkcraftCore/src/org/workcraft/gui/MainMenu.java
@@ -106,9 +106,6 @@ public class MainMenu extends JMenuBar {
         ActionMenuItem miSaveWorkspaceAs = new ActionMenuItem(WorkspaceWindow.Actions.SAVE_WORKSPACE_AS_ACTION);
         miSaveWorkspaceAs.addScriptedActionListener(mainWindow.getDefaultActionListener());
 
-        ActionMenuItem miReconfigure = new ActionMenuItem(MainWindowActions.RECONFIGURE_PLUGINS_ACTION);
-        miReconfigure.addScriptedActionListener(mainWindow.getDefaultActionListener());
-
         ActionMenuItem miShutdownGUI = new ActionMenuItem(MainWindowActions.SHUTDOWN_GUI_ACTION);
         miShutdownGUI.addScriptedActionListener(mainWindow.getDefaultActionListener());
 
@@ -140,7 +137,6 @@ public class MainMenu extends JMenuBar {
 //        mnFile.add(miSaveWorkspaceAs);
 
         mnFile.addSeparator();
-        mnFile.add(miReconfigure);
         mnFile.add(miShutdownGUI);
         mnFile.addSeparator();
         mnFile.add(miExit);

--- a/WorkcraftCore/src/org/workcraft/gui/MainWindowActions.java
+++ b/WorkcraftCore/src/org/workcraft/gui/MainWindowActions.java
@@ -5,9 +5,7 @@ import java.net.URISyntaxException;
 
 import org.workcraft.Framework;
 import org.workcraft.Info;
-import org.workcraft.PluginManager;
 import org.workcraft.exceptions.OperationCancelledException;
-import org.workcraft.exceptions.PluginInstantiationException;
 import org.workcraft.gui.actions.Action;
 import org.workcraft.gui.graph.tools.GraphEditor;
 import org.workcraft.util.GUI;
@@ -123,23 +121,6 @@ public class MainWindowActions {
             try {
                 mainWindow.closeEditorWindows();
             } catch (OperationCancelledException e) {
-            }
-        }
-    };
-
-    public static final Action RECONFIGURE_PLUGINS_ACTION = new Action() {
-        @Override
-        public String getText() {
-            return "Reconfigure plugins";
-        }
-        @Override
-        public void run() {
-            final Framework framework = Framework.getInstance();
-            PluginManager pm = framework.getPluginManager();
-            try {
-                pm.reconfigureManifest(true);
-            } catch (PluginInstantiationException e) {
-                LogUtils.logErrorLine(e.getMessage());
             }
         }
     };


### PR DESCRIPTION
This simplifies adding new plugins and removing old plugins.
Redundant code for loading/saving plugin manifest is removed.

Closes #677