### PR TITLE
Generate md5 checksums for archives when preparing distribution

### DIFF
--- a/dist/run.sh
+++ b/dist/run.sh
@@ -162,9 +162,11 @@ for platform in $platforms; do
     case $platform in
         windows)
             7z a -r ${dist_name}.zip $dist_rootdir >/dev/null
+            md5sum ${dist_name}.zip > ${dist_name}.zip.md5
             ;;
         linux | osx)
             tar -czf ${dist_name}.tar.gz $dist_rootdir
+            md5sum ${dist_name}.tar.gz > ${dist_name}.tar.gz.md5
             ;;
     esac
 


### PR DESCRIPTION
The .md5 files can be supplied along with archives, or the raw checksum can be posted on the site next to the download.

Possible to add `md5sum -c` afterwards to check successful checksum creation.

This doesn't constitute a security check -- integrity check only.