### PR TITLE
Update Gradle JavaCC plugin to latest version (3.0.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'ca.coglinc.javacc'
+    id 'org.javacc.javacc'
     id 'com.github.kt3k.coveralls'
     id 'de.aaschmid.cpd'
     id 'com.github.jk1.dependency-license-report'
@@ -33,7 +33,7 @@ subprojects {
         }
     }
 
-    apply plugin: 'ca.coglinc.javacc'
+    apply plugin: 'org.javacc.javacc'
 
     compileJavacc {
         inputDirectory = file('javacc')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     plugins {
-        // Plugin for JavaCC parser generator (https://plugins.gradle.org/plugin/ca.coglinc.javacc)
-        id 'ca.coglinc.javacc' version '2.4.0'
+        // Plugin for JavaCC parser generator (https://plugins.gradle.org/plugin/org.javacc.javacc)
+        id 'org.javacc.javacc' version '3.0.0'
         // Plugin for sending Jacoco coverage reports to coveralls.io (https://plugins.gradle.org/plugin/com.github.kt3k.coveralls)
         id 'com.github.kt3k.coveralls' version '2.12.2'
         // Plugin for PMD-based Copy-Paste Detection (https://plugins.gradle.org/plugin/de.aaschmid.cpd)


### PR DESCRIPTION
New version of the JavaCC plugin is out: [release notes](https://github.com/javacc/javaccPlugin/releases/tag/javacc-gradle-plugin-3.0.0). Because the plugin ID changed, it won't be found by usual dependency update mechanisms, so I'm making  PRs manually to update the major projects on GitHub that are using an older version of the plugin.

The new version should make compilation of the parser a bit faster and improve compatibility with future releases of Gradle.

I locally checked that `./gradlew test` is successful with this change, but have not done any other testing.