### PR TITLE
Improve position of reset and scan ports

### DIFF
--- a/workcraft/CircuitPlugin/src/org/workcraft/plugins/circuit/utils/ResetUtils.java
+++ b/workcraft/CircuitPlugin/src/org/workcraft/plugins/circuit/utils/ResetUtils.java
@@ -205,8 +205,7 @@ public final class ResetUtils {
         for (VisualFunctionComponent component : resetComponents) {
             insertReset(circuit, component, resetPort, isActiveLow);
         }
-        SpaceUtils.positionPort(circuit, resetPort, false);
-        CircuitUtils.detachJoint(circuit, resetPort, 0.5);
+        SpaceUtils.positionPortAtBottom(circuit, resetPort, false);
         setInitialisationProtocol(circuit, resetPort, isActiveLow);
         return true;
     }
@@ -227,6 +226,7 @@ public final class ResetUtils {
             appendResetToComponent(circuit, component, resetPort, isActiveLow);
         } else {
             CircuitUtils.connectIfPossible(circuit, resetPort, resetInputPin);
+            ConversionUtils.replicateDriverContact(circuit, resetInputPin);
         }
         return true;
     }
@@ -389,6 +389,7 @@ public final class ResetUtils {
         if (!forcedInitOutputs.isEmpty()) {
             VisualFunctionContact initContact = getOrCreateResetPin(circuit, component, initGatePinPair.getSecond());
             CircuitUtils.connectIfPossible(circuit, resetPort, initContact);
+            ConversionUtils.replicateDriverContact(circuit, initContact);
             for (VisualFunctionContact contact : forcedInitOutputs) {
                 insertResetFunction(contact, initContact, isActiveLow);
             }

--- a/workcraft/WorkcraftCore/src/org/workcraft/Info.java
+++ b/workcraft/WorkcraftCore/src/org/workcraft/Info.java
@@ -17,7 +17,7 @@ public class Info {
     private static final String SUBTITLE_3 = "Return of the Hazard";
     private static final String SUBTITLE_4 = "Revenge of the Timing Assumption";
 
-    private static final Version VERSION = new Version(3, 5, 2, Status.ALPHA);
+    private static final Version VERSION = new Version(3, 5, 2, Status.BETA);
 
     private static final int START_YEAR = 2006;
     private static final int CURRENT_YEAR = Calendar.getInstance().get(Calendar.YEAR);


### PR DESCRIPTION
Position ports at the bottom of circuit schematic.
Align new ports with existing ports.
Make use of proxy contacts to reduce clutter.