### PR TITLE
ctfl-graph: replace string vertices with Vertex record

### DIFF
--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/algorithms/EdgeCliqueCoverHeuristic.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/algorithms/EdgeCliqueCoverHeuristic.java
@@ -2,6 +2,7 @@ package org.workcraft.plugins.cflt.algorithms;
 
 import org.workcraft.plugins.cflt.graph.Clique;
 import org.workcraft.plugins.cflt.graph.Edge;
+import org.workcraft.plugins.cflt.graph.Vertex;
 import org.workcraft.plugins.cflt.graph.Graph;
 
 import java.util.*;
@@ -11,28 +12,29 @@ public class EdgeCliqueCoverHeuristic {
 
     List<Clique> finalCliques = new ArrayList<>();
 
-    Map<String, Integer> vertexNameToUncoveredDegree = new HashMap<>();
-    Map<String, Integer> vertexNameToLocalUncoveredDegree = new HashMap<>();
-    Map<String, Set<String>> vertexNameToAllNeighbours = new HashMap<>();
+    Map<Vertex, Integer> vertexToUncoveredDegree = new HashMap<>();
+    Map<Vertex, Integer> vertexToLocalUncoveredDegree = new HashMap<>();
+    Map<Vertex, Set<Vertex>> vertexToAllNeighbours = new HashMap<>();
 
-    Map<String, Integer> edgeNameToNoOfCliquesItsContainedIn = new HashMap<>();
-    Map<String, Boolean> edgeNameToIsCovered = new HashMap<>();
+    Map<Edge, Integer> edgeToNoOfCliquesItsContainedIn = new HashMap<>();
+    Map<Edge, Boolean> edgeToIsCovered = new HashMap<>();
 
-    Set<String> uncoveredVertexNames = new HashSet<>();
-    Set<String> optionalEdgeNames = new HashSet<>();
+    Set<Vertex> uncoveredVertices = new HashSet<>();
+    Set<Edge> optionalEdges = new HashSet<>();
 
     public List<Clique> getEdgeCliqueCover(Graph graph, List<Edge> optionalEdges, HeuristicType heuristicType) {
 
-        initialiseHeuristicDataStructures(graph, optionalEdges);
+        initialiseHeuristicDataStructures(graph);
+        this.optionalEdges = new HashSet<>(optionalEdges);
 
         int cliqueNumber = -1;
         int maxCliqueSize = 0;
         int currentCliqueSize = 0;
 
-        while (!uncoveredVertexNames.isEmpty()) {
-            String i = selectVertex(heuristicType);
+        while (!uncoveredVertices.isEmpty()) {
+            Vertex i = selectVertex(heuristicType);
 
-            while (vertexNameToUncoveredDegree.get(i) > 0) {
+            while (vertexToUncoveredDegree.get(i) > 0) {
                 if (currentCliqueSize > maxCliqueSize) {
                     maxCliqueSize = currentCliqueSize;
                 }
@@ -41,56 +43,56 @@ public class EdgeCliqueCoverHeuristic {
                 cliqueNumber += 1;
 
                 finalCliques.add(cliqueNumber, new Clique());
-                finalCliques.get(cliqueNumber).addVertexName(i);
+                finalCliques.get(cliqueNumber).addVertex(i);
 
-                HashSet<String> localNeighbourhoodOfi = new HashSet<>(vertexNameToAllNeighbours.get(i));
+                HashSet<Vertex> localNeighbourhoodOfi = new HashSet<>(vertexToAllNeighbours.get(i));
 
-                for (String j : localNeighbourhoodOfi) {
-                    String edgeName = getEdgeName(i, j);
-                    boolean isCovered = edgeNameToIsCovered.get(edgeName);
+                for (Vertex j : localNeighbourhoodOfi) {
+                    Edge edge = new Edge(i, j);
+                    boolean isCovered = edgeToIsCovered.get(edge);
 
-                    vertexNameToLocalUncoveredDegree.put(j, 1 - (isCovered ? 1 : 0));
+                    vertexToLocalUncoveredDegree.put(j, 1 - (isCovered ? 1 : 0));
                 }
-                String u = argMax(vertexNameToLocalUncoveredDegree, localNeighbourhoodOfi);
+                Vertex u = argMax(vertexToLocalUncoveredDegree, localNeighbourhoodOfi);
 
-                while (vertexNameToLocalUncoveredDegree.get(u) > 0) {
+                while (vertexToLocalUncoveredDegree.get(u) > 0) {
                     boolean isOptional = true;
 
-                    for (String j : finalCliques.get(cliqueNumber).getVertexNames()) {
-                        String edgeNameUj = getEdgeName(u, j);
-                        String edgeNameJi = getEdgeName(j, i);
+                    for (Vertex j : finalCliques.get(cliqueNumber).getVertices()) {
+                        Edge edgeUj = new Edge(u, j);
+                        Edge edgeJi = new Edge(j, i);
 
-                        if (!edgeNameToIsCovered.get(edgeNameUj)) {
-                            edgeNameToIsCovered.replace(edgeNameUj, true);
+                        if (!edgeToIsCovered.get(edgeUj)) {
+                            edgeToIsCovered.replace(edgeUj, true);
 
-                            vertexNameToUncoveredDegree.merge(u, -1, Integer::sum);
-                            vertexNameToUncoveredDegree.merge(j, -1, Integer::sum);
+                            vertexToUncoveredDegree.merge(u, -1, Integer::sum);
+                            vertexToUncoveredDegree.merge(j, -1, Integer::sum);
                         }
 
-                        finalCliques.get(cliqueNumber).addEdgeName(edgeNameUj);
-                        finalCliques.get(cliqueNumber).addEdgeName(edgeNameJi);
+                        finalCliques.get(cliqueNumber).addEdge(edgeUj);
+                        finalCliques.get(cliqueNumber).addEdge(edgeJi);
 
-                        edgeNameToNoOfCliquesItsContainedIn.merge(edgeNameUj, 1, Integer::sum);
-                        if (!optionalEdgeNames.contains(edgeNameUj)) isOptional = false;
+                        edgeToNoOfCliquesItsContainedIn.merge(edgeUj, 1, Integer::sum);
+                        if (!optionalEdges.contains(edgeUj)) isOptional = false;
                     }
-                    if (!isOptional) finalCliques.get(cliqueNumber).addVertexName(u);
+                    if (!isOptional) finalCliques.get(cliqueNumber).addVertex(u);
 
                     currentCliqueSize += 1;
-                    localNeighbourhoodOfi.retainAll(vertexNameToAllNeighbours.get(u));
+                    localNeighbourhoodOfi.retainAll(vertexToAllNeighbours.get(u));
 
-                    for (String j : localNeighbourhoodOfi) {
-                        String edgeName = getEdgeName(u, j);
+                    for (Vertex j : localNeighbourhoodOfi) {
+                        Edge edge = new Edge(u, j);
 
-                        if (!edgeNameToIsCovered.get(edgeName)) {
-                            vertexNameToLocalUncoveredDegree.merge(j, 1, Integer::sum);
+                        if (!edgeToIsCovered.get(edge)) {
+                            vertexToLocalUncoveredDegree.merge(j, 1, Integer::sum);
                         }
                     }
 
-                    u = argMax(vertexNameToLocalUncoveredDegree, localNeighbourhoodOfi);
+                    u = argMax(vertexToLocalUncoveredDegree, localNeighbourhoodOfi);
                     if (localNeighbourhoodOfi.isEmpty()) break;
                 }
             }
-            uncoveredVertexNames = updateUncoveredVertices();
+            uncoveredVertices = updateUncoveredVertices();
         }
 
         handleNonMaximalCliques(maxCliqueSize);
@@ -98,34 +100,28 @@ public class EdgeCliqueCoverHeuristic {
         return removeCliquesConsistingOfOptionalEdges();
     }
 
-    private void initialiseHeuristicDataStructures(Graph graph, List<Edge> optionalEdges) {
+    private void initialiseHeuristicDataStructures(Graph graph) {
         for (Edge edge : graph.getEdges()) {
-            vertexNameToAllNeighbours
-                    .computeIfAbsent(edge.firstVertexName(), k -> new HashSet<>())
-                    .add(edge.secondVertexName());
-            vertexNameToAllNeighbours
-                    .computeIfAbsent(edge.secondVertexName(), k -> new HashSet<>())
-                    .add(edge.firstVertexName());
-        }
-
-        for (Edge edge : optionalEdges) {
-            String edgeName = getEdgeName(edge.firstVertexName(), edge.secondVertexName());
-            optionalEdgeNames.add(edgeName);
+            vertexToAllNeighbours
+                    .computeIfAbsent(edge.firstVertex(), k -> new HashSet<>())
+                    .add(edge.secondVertex());
+            vertexToAllNeighbours
+                    .computeIfAbsent(edge.secondVertex(), k -> new HashSet<>())
+                    .add(edge.firstVertex());
         }
 
         for (Edge edge : graph.getEdges()) {
-            String edgeName = getEdgeName(edge.firstVertexName(), edge.secondVertexName());
-            edgeNameToIsCovered.put(edgeName, false);
-            edgeNameToNoOfCliquesItsContainedIn.put(edgeName, 0);
+            edgeToIsCovered.put(edge, false);
+            edgeToNoOfCliquesItsContainedIn.put(edge, 0);
         }
 
-        for (String vertexName : graph.getVertexNames()) {
-            Set<String> neighbours = vertexNameToAllNeighbours.get(vertexName);
+        for (Vertex vertexName : graph.getVertices()) {
+            Set<Vertex> neighbours = vertexToAllNeighbours.get(vertexName);
             if (neighbours != null && !neighbours.isEmpty()) {
-                vertexNameToUncoveredDegree.put(vertexName, neighbours.size());
-                uncoveredVertexNames.add(vertexName);
+                vertexToUncoveredDegree.put(vertexName, neighbours.size());
+                uncoveredVertices.add(vertexName);
             } else {
-                vertexNameToUncoveredDegree.put(vertexName, 0);
+                vertexToUncoveredDegree.put(vertexName, 0);
             }
         }
     }
@@ -134,9 +130,9 @@ public class EdgeCliqueCoverHeuristic {
         Iterator<Clique> iterator = finalCliques.iterator();
         while (iterator.hasNext()) {
             Clique clique = iterator.next();
-            if (isCliqueRedundant(clique.getEdgeNames())) {
-                for (String edge : clique.getEdgeNames()) {
-                    edgeNameToNoOfCliquesItsContainedIn.merge(edge, -1, Integer::sum);
+            if (isCliqueRedundant(clique.getEdges())) {
+                for (Edge edge : clique.getEdges()) {
+                    edgeToNoOfCliquesItsContainedIn.merge(edge, -1, Integer::sum);
                 }
                 iterator.remove();
             }
@@ -147,8 +143,8 @@ public class EdgeCliqueCoverHeuristic {
         return finalCliques
                 .stream()
                 .map(finalClique -> {
-                    List<String> edgeNames = finalClique.getEdgeNames();
-                    boolean containsOnlyOptionalEdges = optionalEdgeNames.containsAll(edgeNames);
+                    List<Edge> edges = finalClique.getEdges();
+                    boolean containsOnlyOptionalEdges = optionalEdges.containsAll(edges);
                     return containsOnlyOptionalEdges
                             ? new Clique()
                             : finalClique;
@@ -160,30 +156,30 @@ public class EdgeCliqueCoverHeuristic {
         int currentCliqueIndex = 0;
 
         for (Clique clique : finalCliques) {
-            if (clique.getVertexNames().size() < maxCliqueSize && !clique.getVertexNames().isEmpty()) {
-                String firstClique = clique.getVertexNames().get(0);
-                Set<String> firstCliqueNeighbours = vertexNameToAllNeighbours.get(firstClique);
+            if (clique.getVertices().size() < maxCliqueSize && !clique.getVertices().isEmpty()) {
+                Vertex firstClique = clique.getVertices().get(0);
+                Set<Vertex> firstCliqueNeighbours = vertexToAllNeighbours.get(firstClique);
 
-                Set<String> neighboursOfFirstVertex = new HashSet<>(firstCliqueNeighbours);
-                List<String> verticesToBeAdded = new ArrayList<>(neighboursOfFirstVertex);
+                Set<Vertex> neighboursOfFirstVertex = new HashSet<>(firstCliqueNeighbours);
+                List<Vertex> verticesToBeAdded = new ArrayList<>(neighboursOfFirstVertex);
 
-                for (int x = 1; x < clique.getVertexNames().size(); x++) {
-                    String currentClique = clique.getVertexNames().get(x);
-                    Set<String> currentCliqueNeighbours = vertexNameToAllNeighbours.get(currentClique);
+                for (int x = 1; x < clique.getVertices().size(); x++) {
+                    Vertex currentClique = clique.getVertices().get(x);
+                    Set<Vertex> currentCliqueNeighbours = vertexToAllNeighbours.get(currentClique);
                     verticesToBeAdded.retainAll(currentCliqueNeighbours);
                 }
 
                 while (!verticesToBeAdded.isEmpty()) {
-                    String i = verticesToBeAdded.get(0);
-                    clique.addVertexName(i);
-                    Set<String> neighboursOfi = vertexNameToAllNeighbours.get(i);
+                    Vertex i = verticesToBeAdded.get(0);
+                    clique.addVertex(i);
+                    Set<Vertex> neighboursOfi = vertexToAllNeighbours.get(i);
                     verticesToBeAdded.retainAll(neighboursOfi);
 
-                    for (String s : clique.getVertexNames()) {
+                    for (Vertex s : clique.getVertices()) {
                         if (!i.equals(s)) {
-                            String edgeName = getEdgeName(i, s);
-                            finalCliques.get(currentCliqueIndex).addEdgeName(edgeName);
-                            edgeNameToNoOfCliquesItsContainedIn.merge(edgeName, 1, Integer::sum);
+                            Edge edge = new Edge(i, s);
+                            finalCliques.get(currentCliqueIndex).addEdge(edge);
+                            edgeToNoOfCliquesItsContainedIn.merge(edge, 1, Integer::sum);
                         }
                     }
                 }
@@ -192,44 +188,37 @@ public class EdgeCliqueCoverHeuristic {
         }
     }
 
-    private String argMin(Map<String, Integer> uncoveredDegree, Set<String> uncoveredVertices) {
+    private Vertex argMin(Map<Vertex, Integer> uncoveredDegree, Set<Vertex> uncoveredVertices) {
         return uncoveredVertices
                 .stream()
                 .min(Comparator.comparingInt(uncoveredDegree::get))
                 .orElse(null);
     }
 
-    private String argMax(Map<String, Integer> uncoveredDegree, Set<String> uncoveredVertices) {
+    private Vertex argMax(Map<Vertex, Integer> uncoveredDegree, Set<Vertex> uncoveredVertices) {
         return uncoveredVertices
                 .stream()
                 .max(Comparator.comparingInt(uncoveredDegree::get))
                 .orElse(null);
     }
 
-    private boolean isCliqueRedundant(List<String> edgeNames) {
-        return edgeNames
+    private boolean isCliqueRedundant(List<Edge> edges) {
+        return edges
                 .stream()
-                .allMatch(edge -> edgeNameToNoOfCliquesItsContainedIn.getOrDefault(edge, 0) > 1);
+                .allMatch(edge -> edgeToNoOfCliquesItsContainedIn.getOrDefault(edge, 0) > 1);
     }
 
-    private Set<String> updateUncoveredVertices() {
-        return uncoveredVertexNames.stream()
-                .filter(v -> vertexNameToUncoveredDegree.get(v) > 0)
+    private Set<Vertex> updateUncoveredVertices() {
+        return uncoveredVertices.stream()
+                .filter(v -> vertexToUncoveredDegree.get(v) > 0)
                 .collect(Collectors.toSet());
     }
 
-    // TODO: There's a more efficient way to do this for sure
-    private String getEdgeName(String vertexName1, String vertexName2) {
-        return (vertexName1.compareTo(vertexName2) < 0)
-                ? vertexName1 + vertexName2
-                : vertexName2 + vertexName1;
-    }
-
-    private String selectVertex(HeuristicType heuristicType) {
+    private Vertex selectVertex(HeuristicType heuristicType) {
         return switch (heuristicType) {
-            case MAXIMAL -> argMax(vertexNameToUncoveredDegree, uncoveredVertexNames);
-            case MINIMAL -> argMin(vertexNameToUncoveredDegree, uncoveredVertexNames);
-            case SEQUENCE -> uncoveredVertexNames.iterator().next();
+            case MAXIMAL -> argMax(vertexToUncoveredDegree, uncoveredVertices);
+            case MINIMAL -> argMin(vertexToUncoveredDegree, uncoveredVertices);
+            case SEQUENCE -> uncoveredVertices.iterator().next();
         };
     }
 }

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/algorithms/MaxCliqueEnumerator.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/algorithms/MaxCliqueEnumerator.java
@@ -2,6 +2,7 @@ package org.workcraft.plugins.cflt.algorithms;
 
 import org.workcraft.plugins.cflt.graph.Clique;
 import org.workcraft.plugins.cflt.graph.Graph;
+import org.workcraft.plugins.cflt.graph.Vertex;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,15 +13,15 @@ import java.util.Map;
 public class MaxCliqueEnumerator {
 
     int nodeCount;
-    List<Vertex> graph = new ArrayList<>();
+    List<EnumeratorVertex> graph = new ArrayList<>();
     List<Clique> allMaxCliques = new ArrayList<>();
-    Map<String, Integer> vertexNameToIndex = new HashMap<>();
-    Map<Integer, String> vertexIndexToName = new HashMap<>();
+    Map<Vertex, Integer> vertexToIndex = new HashMap<>();
+    Map<Integer, Vertex> indexToVertex = new HashMap<>();
 
-    static class Vertex implements Comparable<Vertex> {
+    static class EnumeratorVertex implements Comparable<EnumeratorVertex> {
         int x;
         int degree;
-        ArrayList<Vertex> neighbours = new ArrayList<>();
+        ArrayList<EnumeratorVertex> neighbours = new ArrayList<>();
 
         int getX() {
             return x;
@@ -30,11 +31,11 @@ public class MaxCliqueEnumerator {
             this.x = x;
         }
 
-        ArrayList<Vertex> getNeighbours() {
+        ArrayList<EnumeratorVertex> getNeighbours() {
             return neighbours;
         }
 
-        void addNeighbour(Vertex vertex) {
+        void addNeighbour(EnumeratorVertex vertex) {
             this.neighbours.add(vertex);
             if (!vertex.getNeighbours().contains(vertex)) {
                 vertex.getNeighbours().add(this);
@@ -44,7 +45,7 @@ public class MaxCliqueEnumerator {
 
         }
 
-        void removeNeighbour(Vertex vertex) {
+        void removeNeighbour(EnumeratorVertex vertex) {
             this.neighbours.remove(vertex);
             if (vertex.getNeighbours().contains(vertex)) {
                 vertex.getNeighbours().remove(this);
@@ -54,7 +55,7 @@ public class MaxCliqueEnumerator {
         }
 
         @Override
-        public int compareTo(Vertex o) {
+        public int compareTo(EnumeratorVertex o) {
             return Integer.compare(this.degree, o.degree);
         }
     }
@@ -71,46 +72,46 @@ public class MaxCliqueEnumerator {
     private void initGraph() {
         graph.clear();
         for (int i = 0; i < nodeCount; i++) {
-            Vertex v = new Vertex();
+            EnumeratorVertex v = new EnumeratorVertex();
             v.setX(i);
             graph.add(v);
         }
     }
 
     private void readNextGraph(Graph g) {
-        nodeCount = g.getVertexNames().size();
+        nodeCount = g.getVertices().size();
         int edgesCount = g.getEdges().size();
         initGraph();
 
         for (int k = 0; k < edgesCount; k++) {
-            String[] strArr = new String[2];
-            strArr[0] = g.getEdges().get(k).firstVertexName();
-            strArr[1] = g.getEdges().get(k).secondVertexName();
-            int u = vertexNameToIndex.get(strArr[0]);
-            int v = vertexNameToIndex.get(strArr[1]);
-            Vertex vertexU = graph.get(u);
-            Vertex vertexV = graph.get(v);
+            Vertex[] vertexArray = new Vertex[2];
+            vertexArray[0] = g.getEdges().get(k).firstVertex();
+            vertexArray[1] = g.getEdges().get(k).secondVertex();
+            int u = vertexToIndex.get(vertexArray[0]);
+            int v = vertexToIndex.get(vertexArray[1]);
+            EnumeratorVertex vertexU = graph.get(u);
+            EnumeratorVertex vertexV = graph.get(v);
             vertexU.addNeighbour(vertexV);
         }
     }
-    private ArrayList<Vertex> getNeighbours(Vertex v) {
+    private ArrayList<EnumeratorVertex> getNeighbours(EnumeratorVertex v) {
         int i = v.getX();
         return graph.get(i).neighbours;
     }
-    private List<Vertex> intersect(List<Vertex> arlFirst,
-            List<Vertex> arlSecond) {
-        List<Vertex> arlHold = new ArrayList<>(arlFirst);
+    private List<EnumeratorVertex> intersect(List<EnumeratorVertex> arlFirst,
+            List<EnumeratorVertex> arlSecond) {
+        List<EnumeratorVertex> arlHold = new ArrayList<>(arlFirst);
         arlHold.retainAll(arlSecond);
         return arlHold;
     }
-    private void bronKerboschWithoutPivot(List<Vertex> r, List<Vertex> p, List<Vertex> x, String pre) {
+    private void bronKerboschWithoutPivot(List<EnumeratorVertex> r, List<EnumeratorVertex> p, List<EnumeratorVertex> x, String pre) {
         if (p.isEmpty() && x.isEmpty()) {
             saveClique(r);
             return;
         }
 
-        ArrayList<Vertex> p1 = new ArrayList<>(p);
-        for (Vertex v : p) {
+        ArrayList<EnumeratorVertex> p1 = new ArrayList<>(p);
+        for (EnumeratorVertex v : p) {
             r.add(v);
             bronKerboschWithoutPivot(r, intersect(p1, getNeighbours(v)),
                     intersect(x, getNeighbours(v)), pre + "\t");
@@ -120,22 +121,22 @@ public class MaxCliqueEnumerator {
         }
     }
     private void bronKerboschPivotExecute() {
-        List<Vertex> x = new ArrayList<>();
-        List<Vertex> r = new ArrayList<>();
-        List<Vertex> p = new ArrayList<>(graph);
+        List<EnumeratorVertex> x = new ArrayList<>();
+        List<EnumeratorVertex> r = new ArrayList<>();
+        List<EnumeratorVertex> p = new ArrayList<>(graph);
         bronKerboschWithoutPivot(r, p, x, "");
     }
-    private void saveClique(List<Vertex> r) {
+    private void saveClique(List<EnumeratorVertex> r) {
         Clique maxClique = new Clique();
-        for (Vertex v : r) {
-            maxClique.addVertexName(vertexIndexToName.get(v.getX()));
+        for (EnumeratorVertex v : r) {
+            maxClique.addVertex(indexToVertex.get(v.getX()));
         }
         allMaxCliques.add(maxClique);
     }
     private void initialiseMap(Graph graph) {
-        for (int i = 0; i < graph.getVertexNames().size(); i++) {
-            vertexNameToIndex.put(graph.getVertexNames().get(i), i);
-            vertexIndexToName.put(i, graph.getVertexNames().get(i));
+        for (int i = 0; i < graph.getVertices().size(); i++) {
+            vertexToIndex.put(graph.getVertices().get(i), i);
+            indexToVertex.put(i, graph.getVertices().get(i));
         }
     }
 }

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/AdvancedGraph.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/AdvancedGraph.java
@@ -9,18 +9,18 @@ import java.util.*;
 public class AdvancedGraph extends Graph {
 
     // All common neighbours of each of the vertices of the edge
-    private final HashMap<Edge, HashSet<String>> edgeNameToAllCommonNeighbours = new HashMap<>();
+    private final HashMap<Edge, HashSet<Vertex>> edgeToAllCommonNeighbours = new HashMap<>();
 
     // Number of edges interconnecting the common (uncovered) neighbours of both vertices of the edge (excluding the edge itself)
     private final HashMap<Edge, Integer> edgeToCn = new HashMap<>();
-    private final HashMap<String, Edge> allEdgeNames = new HashMap<>();
+    private final HashSet<Edge> allEdges = new HashSet<>();
     private HashSet<Edge> coveredEdges = new HashSet<>();
 
-    private final HashMap<String, HashSet<String>> vertexNameToAllNeighbours = new HashMap<>();
-    private final HashMap<String, HashSet<String>> vertexNameToUncoveredNeighbours = new HashMap<>();
+    private final HashMap<Vertex, HashSet<Vertex>> vertexToAllNeighbours = new HashMap<>();
+    private final HashMap<Vertex, HashSet<Vertex>> vertexToUncoveredNeighbours = new HashMap<>();
 
     // This set is used to make sure that the same cliques is not covered twice for example abc and acb
-    private HashSet<HashSet<String>> usedVertexNameSets = new HashSet<>();
+    private HashSet<HashSet<Vertex>> usedVertexSets = new HashSet<>();
 
     private final List<Clique> allMaxCliques;
 
@@ -28,36 +28,36 @@ public class AdvancedGraph extends Graph {
         this.allMaxCliques = allMaxCliques;
 
         for (Edge edge : graph.getEdges()) {
-            String firstVertexName = edge.firstVertexName();
-            String secondVertexName = edge.secondVertexName();
+            Vertex firstVertex = edge.firstVertex();
+            Vertex secondVertex = edge.secondVertex();
 
-            if (!vertexNameToAllNeighbours.containsKey(firstVertexName)) {
-                vertexNameToAllNeighbours.put(firstVertexName, new HashSet<>());
-                vertexNameToUncoveredNeighbours.put(firstVertexName, new HashSet<>());
+            if (!vertexToAllNeighbours.containsKey(firstVertex)) {
+                vertexToAllNeighbours.put(firstVertex, new HashSet<>());
+                vertexToUncoveredNeighbours.put(firstVertex, new HashSet<>());
             }
-            vertexNameToAllNeighbours.get(firstVertexName).add(secondVertexName);
-            vertexNameToUncoveredNeighbours.get(firstVertexName).add(secondVertexName);
+            vertexToAllNeighbours.get(firstVertex).add(secondVertex);
+            vertexToUncoveredNeighbours.get(firstVertex).add(secondVertex);
 
-            if (!vertexNameToAllNeighbours.containsKey(secondVertexName)) {
-                vertexNameToAllNeighbours.put(secondVertexName, new HashSet<>());
-                vertexNameToUncoveredNeighbours.put(secondVertexName, new HashSet<>());
+            if (!vertexToAllNeighbours.containsKey(secondVertex)) {
+                vertexToAllNeighbours.put(secondVertex, new HashSet<>());
+                vertexToUncoveredNeighbours.put(secondVertex, new HashSet<>());
             }
-            vertexNameToAllNeighbours.get(secondVertexName).add(firstVertexName);
-            vertexNameToUncoveredNeighbours.get(secondVertexName).add(firstVertexName);
+            vertexToAllNeighbours.get(secondVertex).add(firstVertex);
+            vertexToUncoveredNeighbours.get(secondVertex).add(firstVertex);
 
-            allEdgeNames.put(firstVertexName + secondVertexName, edge);
+            allEdges.add(edge);
         }
 
         for (Edge edge : graph.getEdges()) {
-            String firstVertexName = edge.firstVertexName();
-            String secondVertexName = edge.secondVertexName();
+            Vertex firstVertex = edge.firstVertex();
+            Vertex secondVertex = edge.secondVertex();
 
-            Set<String> firstVertexNeighbours = vertexNameToAllNeighbours.getOrDefault(firstVertexName, new HashSet<>());
-            Set<String> secondVertexNeighbours = vertexNameToAllNeighbours.getOrDefault(secondVertexName, new HashSet<>());
+            Set<Vertex> firstVertexNeighbours = vertexToAllNeighbours.getOrDefault(firstVertex, new HashSet<>());
+            Set<Vertex> secondVertexNeighbours = vertexToAllNeighbours.getOrDefault(secondVertex, new HashSet<>());
 
-            HashSet<String> commonNeighbours = new HashSet<>(firstVertexNeighbours);
+            HashSet<Vertex> commonNeighbours = new HashSet<>(firstVertexNeighbours);
             commonNeighbours.retainAll(secondVertexNeighbours);
-            edgeNameToAllCommonNeighbours.put(edge, commonNeighbours);
+            edgeToAllCommonNeighbours.put(edge, commonNeighbours);
             edgeToCn.put(edge, getCommonNeighbourCount(commonNeighbours));
         }
     }
@@ -74,38 +74,38 @@ public class AdvancedGraph extends Graph {
 
     public boolean isCovered(List<Clique> edgeCliqueCover, List<Edge> optionalEdges) {
         coveredEdges = new HashSet<>();
-        usedVertexNameSets = new HashSet<>();
+        usedVertexSets = new HashSet<>();
         updateSets(edgeCliqueCover);
         if (optionalEdges != null) {
             coveredEdges.addAll(optionalEdges);
         }
-        return allEdgeNames.size() <= coveredEdges.size();
+        return allEdges.size() <= coveredEdges.size();
     }
 
     public List<Clique> getMaximalCliques(Edge edge) {
         List<Clique> cliques = new ArrayList<>();
-        HashSet<String> commonNeighbours = edgeNameToAllCommonNeighbours.get(edge);
+        HashSet<Vertex> commonNeighbours = edgeToAllCommonNeighbours.get(edge);
 
-        String firstVertexName = edge.firstVertexName();
-        String secondVertexName = edge.secondVertexName();
+        Vertex firstVertex = edge.firstVertex();
+        Vertex secondVertex = edge.secondVertex();
 
         if ((commonNeighbours == null) || commonNeighbours.isEmpty()) {
             Clique clique = new Clique();
-            clique.addVertexName(firstVertexName);
-            clique.addVertexName(secondVertexName);
+            clique.addVertex(firstVertex);
+            clique.addVertex(secondVertex);
             cliques.add(clique);
         } else {
             for (Clique maxClique : allMaxCliques) {
-                List<String> vertexNames = maxClique.getVertexNames();
-                boolean hasFirstVertex = vertexNames.contains(edge.firstVertexName());
-                boolean hasSecondVertex = vertexNames.contains(edge.secondVertexName());
+                List<Vertex> vertices = maxClique.getVertices();
+                boolean hasFirstVertex = vertices.contains(edge.firstVertex());
+                boolean hasSecondVertex = vertices.contains(edge.secondVertex());
 
                 if (hasFirstVertex && hasSecondVertex) {
-                    HashSet<String> usedVertexNameSet = new HashSet<>(vertexNames);
+                    HashSet<Vertex> usedVertexNameSet = new HashSet<>(vertices);
 
-                    if (!usedVertexNameSets.contains(usedVertexNameSet)) {
+                    if (!usedVertexSets.contains(usedVertexNameSet)) {
                         cliques.add(maxClique);
-                        usedVertexNameSets.add(usedVertexNameSet);
+                        usedVertexSets.add(usedVertexNameSet);
                     }
                 }
             }
@@ -120,53 +120,46 @@ public class AdvancedGraph extends Graph {
     }
 
     private void updateCoveredEdges(Clique clique) {
-        for (String firstVertex : clique.getVertexNames()) {
-            for (String secondVertex : clique.getVertexNames()) {
-                if (!firstVertex.equals(secondVertex)) {
+        for (Vertex firstVertex : clique.getVertices()) {
+            for (Vertex secondVertex : clique.getVertices()) {
+                if (firstVertex.equals(secondVertex)) continue;
 
-                    String edgeName1 = firstVertex + secondVertex;
-                    String edgeName2 = secondVertex + firstVertex;
-
-                    if (allEdgeNames.containsKey(edgeName1)) {
-                        coveredEdges.add(allEdgeNames.get(edgeName1));
-                    }
-                    if (allEdgeNames.containsKey(edgeName2)) {
-                        coveredEdges.add(allEdgeNames.get(edgeName2));
-                    }
-
-                    HashSet<String> v1UncoveredNeighbours = vertexNameToUncoveredNeighbours.get(firstVertex);
-                    if (v1UncoveredNeighbours != null) v1UncoveredNeighbours.remove(secondVertex);
-
-                    HashSet<String> v2UncoveredNeighbours = vertexNameToUncoveredNeighbours.get(secondVertex);
-                    if (v2UncoveredNeighbours != null) v2UncoveredNeighbours.remove(firstVertex);
+                Edge edge = new Edge(firstVertex, secondVertex);
+                if (allEdges.contains(edge)) {
+                    coveredEdges.add(edge);
                 }
+
+                HashSet<Vertex> v1UncoveredNeighbours = vertexToUncoveredNeighbours.get(firstVertex);
+                if (v1UncoveredNeighbours != null) v1UncoveredNeighbours.remove(secondVertex);
+
+                HashSet<Vertex> v2UncoveredNeighbours = vertexToUncoveredNeighbours.get(secondVertex);
+                if (v2UncoveredNeighbours != null) v2UncoveredNeighbours.remove(firstVertex);
             }
         }
     }
 
     private void updateUncoveredCommonNeighbours() {
-        for (HashMap.Entry<String, Edge> entry : allEdgeNames.entrySet()) {
+        for (Edge edge : allEdges) {
 
-            String firstVertex = entry.getValue().firstVertexName();
-            String secondVertex = entry.getValue().secondVertexName();
+            Vertex firstVertex = edge.firstVertex();
+            Vertex secondVertex = edge.secondVertex();
 
-            Set<String> commonNeighbours = new HashSet<>(vertexNameToAllNeighbours.getOrDefault(firstVertex, new HashSet<>()));
-            commonNeighbours.retainAll(vertexNameToUncoveredNeighbours.getOrDefault(secondVertex, new HashSet<>()));
+            Set<Vertex> commonNeighbours = new HashSet<>(vertexToAllNeighbours.getOrDefault(firstVertex, new HashSet<>()));
+            commonNeighbours.retainAll(vertexToUncoveredNeighbours.getOrDefault(secondVertex, new HashSet<>()));
 
             int count = getCommonNeighbourCount(commonNeighbours);
-            edgeToCn.replace(entry.getValue(), count);
+            edgeToCn.replace(edge, count);
         }
     }
 
-    private int getCommonNeighbourCount(Set<String> commonNeighbours) {
+    private int getCommonNeighbourCount(Set<Vertex> commonNeighbours) {
         int count = 0;
-        for (String firstNeighbour : commonNeighbours) {
-            for (String secondNeighbour : commonNeighbours) {
-                boolean areEqual = firstNeighbour.equals(secondNeighbour);
-                boolean isV1V2Present = allEdgeNames.containsKey(firstNeighbour + secondNeighbour);
-                boolean isV2V1Present = allEdgeNames.containsKey(secondNeighbour + firstNeighbour);
+        for (Vertex firstNeighbour : commonNeighbours) {
+            for (Vertex secondNeighbour : commonNeighbours) {
+                boolean areVerticesEqual = firstNeighbour.equals(secondNeighbour);
+                boolean isEdgePresent = allEdges.contains(new Edge(firstNeighbour, secondNeighbour));
 
-                if (!areEqual && (isV1V2Present || isV2V1Present)) count++;
+                if (!areVerticesEqual && isEdgePresent) count++;
             }
         }
         count = (count / 2) + (commonNeighbours.size() * 2);

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/Clique.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/Clique.java
@@ -4,22 +4,22 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Clique {
-    List<String> vertexNames = new ArrayList<>();
-    List<String> edgeNames = new ArrayList<>();
+    List<Vertex> vertices = new ArrayList<>();
+    List<Edge> edges = new ArrayList<>();
 
-    public List<String> getVertexNames() {
-        return vertexNames;
+    public List<Vertex> getVertices() {
+        return vertices;
     }
 
-    public List<String> getEdgeNames() {
-        return edgeNames;
+    public List<Edge> getEdges() {
+        return edges;
     }
 
-    public void addEdgeName(String edgeName) {
-        edgeNames.add(edgeName);
+    public void addEdge(Edge edge) {
+        edges.add(edge);
     }
 
-    public void addVertexName(String vertexName) {
-        vertexNames.add(vertexName);
+    public void addVertex(Vertex vertex) {
+        vertices.add(vertex);
     }
 }

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/Edge.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/Edge.java
@@ -1,4 +1,25 @@
 package org.workcraft.plugins.cflt.graph;
 
-public record Edge(String firstVertexName, String secondVertexName) {
+import java.util.Objects;
+
+public record Edge(Vertex firstVertex, Vertex secondVertex) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Edge other)) {
+            return false;
+        }
+
+        return (Objects.equals(firstVertex, other.firstVertex) && Objects.equals(secondVertex, other.secondVertex))
+                || (Objects.equals(firstVertex, other.secondVertex) && Objects.equals(secondVertex, other.firstVertex));
+    }
+
+    @Override
+    public int hashCode() {
+        // Order-independent hash
+        return Objects.hash(firstVertex) + Objects.hash(secondVertex);
+    }
 }

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/Graph.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/Graph.java
@@ -6,47 +6,46 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.workcraft.plugins.cflt.utils.GraphUtils.SPECIAL_CLONE_CHARACTER;
-
 public class Graph {
-    private List<Edge> edges = new ArrayList<>();
-    private List<String> vertexNames = new ArrayList<>();
 
-    public Graph(List<Edge> edges, List<String> vertices) {
+    private List<Edge> edges = new ArrayList<>();
+    private List<Vertex> vertices = new ArrayList<>();
+
+    public Graph(List<Edge> edges, List<Vertex> vertices) {
         this.edges = edges;
-        this.vertexNames = vertices;
+        this.vertices = vertices;
     }
 
     public Graph() {
     }
 
-    public void addVertexName(String vertexName) {
-        this.vertexNames.add(vertexName);
+    public void addVertex(Vertex vertex) {
+        this.vertices.add(vertex);
     }
 
     public void addEdge(Edge edge) {
         this.getEdges().add(edge);
     }
 
-    public List<String> getIsolatedVertices() {
-        if (getEdges().isEmpty()) return new ArrayList<>(this.vertexNames);
+    public List<Vertex> getIsolatedVertices() {
+        if (getEdges().isEmpty()) return new ArrayList<>(this.vertices);
 
-        Set<String> connectedVertices = edges
+        Set<Vertex> connectedVertices = edges
                 .stream()
-                .flatMap(edge -> Stream.of(edge.firstVertexName(), edge.secondVertexName()))
+                .flatMap(edge -> Stream.of(edge.firstVertex(), edge.secondVertex()))
                 .collect(Collectors.toSet());
 
-        return vertexNames
+        return vertices
             .stream()
-            .filter(vertexName -> !connectedVertices.contains(vertexName))
+            .filter(vertex -> !connectedVertices.contains(vertex))
             .collect(Collectors.toCollection(ArrayList::new));
     }
-    public List<String> getVertexNames() {
-        return vertexNames;
+    public List<Vertex> getVertices() {
+        return vertices;
     }
 
-    public void setVertexNames(List<String> vertexNames) {
-        this.vertexNames = vertexNames;
+    public void setVertices(List<Vertex> vertices) {
+        this.vertices = vertices;
     }
 
     public void setEdges(List<Edge> edges) {
@@ -57,19 +56,18 @@ public class Graph {
         return edges;
     }
 
-    public Graph cloneGraph(int counter) {
-        String suffix = SPECIAL_CLONE_CHARACTER + counter;
+    public Graph deepClone(int cloneGeneration) {
 
-        List<String> vertices = this.vertexNames
+        List<Vertex> vertices = this.vertices
                 .stream()
-                .map(vertexName -> vertexName + suffix)
+                .map(vertex -> vertex.clone(cloneGeneration))
                 .collect(Collectors.toCollection(ArrayList::new));
 
         List<Edge> edges = this.getEdges()
                 .stream()
-                .map(edgeName -> new Edge(
-                        edgeName.firstVertexName() + suffix,
-                        edgeName.secondVertexName() + suffix
+                .map(edge -> new Edge(
+                        edge.firstVertex().clone(cloneGeneration),
+                        edge.secondVertex().clone(cloneGeneration)
                 ))
                 .collect(Collectors.toCollection(ArrayList::new));
 

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/Vertex.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/graph/Vertex.java
@@ -1,0 +1,12 @@
+package org.workcraft.plugins.cflt.graph;
+
+public record Vertex(String name, boolean isClone, Integer cloneGeneration) {
+
+    public Vertex(String name) {
+        this(name, false, null);
+    }
+
+    public Vertex clone(int cloneGeneration) {
+        return new Vertex(this.name, true, cloneGeneration);
+    }
+}

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/tools/NodeTraversalTool.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/tools/NodeTraversalTool.java
@@ -1,30 +1,39 @@
 package org.workcraft.plugins.cflt.tools;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.workcraft.plugins.cflt.utils.GraphUtils;
 import org.workcraft.plugins.cflt.graph.Graph;
+import org.workcraft.plugins.cflt.graph.Vertex;
 import org.workcraft.plugins.cflt.Model;
 import org.workcraft.plugins.cflt.node.Node;
 import org.workcraft.plugins.cflt.node.NodeCollection;
 import org.workcraft.plugins.cflt.node.NodeIterator;
 import org.workcraft.plugins.cflt.node.Operator;
 import org.workcraft.plugins.cflt.presets.ExpressionParameters.Mode;
-import org.workcraft.plugins.cflt.utils.GraphUtils;
 import org.workcraft.workspace.WorkspaceEntry;
 
 public class NodeTraversalTool {
     NodeCollection nodeCollection;
 
-    HashMap<String, Graph> entryGraph = new HashMap<>();
-    HashMap<String, Graph> exitGraph = new HashMap<>();
+    HashMap<String, Graph> entryGraphs = new HashMap<>();
+    HashMap<String, Graph> exitGraphs = new HashMap<>();
 
     VisualModelDrawingTool visualModelDrawingTool;
 
     public NodeTraversalTool(NodeCollection nodeCollection, Model model) {
         this.nodeCollection = nodeCollection;
-        if (model == Model.PETRI_NET) visualModelDrawingTool = new PetriDrawingTool(nodeCollection);
-        if (model == Model.STG) visualModelDrawingTool = new StgDrawingTool(nodeCollection);
+        this.visualModelDrawingTool = this.getDrawingTool(model, nodeCollection);
+    }
+
+    private VisualModelDrawingTool getDrawingTool(Model model, NodeCollection nodeCollection) {
+        return switch (model) {
+            case PETRI_NET -> new PetriDrawingTool(nodeCollection);
+            case STG -> new StgDrawingTool(nodeCollection);
+        };
     }
 
     public void drawInterpretedGraph(Mode mode, Model model, WorkspaceEntry we) {
@@ -40,10 +49,10 @@ public class NodeTraversalTool {
             String rightChildName = node.rightChildName();
             Operator operator = node.operator();
 
-            ensureGraphContainsVertex(entryGraph, leftChildName);
-            ensureGraphContainsVertex(entryGraph, rightChildName);
-            ensureGraphContainsVertex(exitGraph, leftChildName);
-            ensureGraphContainsVertex(exitGraph, rightChildName);
+            ensureGraphExists(entryGraphs, leftChildName);
+            ensureGraphExists(entryGraphs, rightChildName);
+            ensureGraphExists(exitGraphs, leftChildName);
+            ensureGraphExists(exitGraphs, rightChildName);
 
             switch (operator) {
                 case CONCURRENCY -> this.handleConcurrency(leftChildName, rightChildName);
@@ -53,7 +62,7 @@ public class NodeTraversalTool {
             }
 
             if (nodeIterator.isLastNode()) {
-                visualModelDrawingTool.drawVisualObjects(entryGraph.get(leftChildName), new Graph(), false, true, mode, we);
+                visualModelDrawingTool.drawVisualObjects(entryGraphs.get(leftChildName), new Graph(), false, true, mode, we);
             }
         }
     }
@@ -62,48 +71,51 @@ public class NodeTraversalTool {
         visualModelDrawingTool.drawSingleTransition(nodeCollection.getSingleTransition(), we);
     }
 
-    private void ensureGraphContainsVertex(Map<String, Graph> graphNameToGraph, String vertexName) {
-        if (!graphNameToGraph.containsKey(vertexName)) {
-            graphNameToGraph.put(vertexName, new Graph());
-            graphNameToGraph.get(vertexName).addVertexName(vertexName);
-        }
+    private void ensureGraphExists(Map<String, Graph> graphs, String key) {
+        graphs.computeIfAbsent(
+                key,
+                vertexName -> new Graph(
+                        new ArrayList<>(),
+                        new ArrayList<>(List.of(new Vertex(vertexName)))
+                )
+        );
     }
 
     private void handleConcurrency(String leftChildName, String rightChildName) {
-        Graph leftEntryGraph = entryGraph.get(leftChildName);
-        Graph rightEntryGraph = entryGraph.get(rightChildName);
-        Graph newEntryGraph =  GraphUtils.disjointUnion(leftEntryGraph, rightEntryGraph);
-        entryGraph.replace(leftChildName, newEntryGraph);
+        Graph leftEntryGraph = entryGraphs.get(leftChildName);
+        Graph rightEntryGraph = entryGraphs.get(rightChildName);
+        Graph newEntryGraph = GraphUtils.disjointUnion(leftEntryGraph, rightEntryGraph);
+        entryGraphs.replace(leftChildName, newEntryGraph);
 
-        Graph leftExitGraph = exitGraph.get(leftChildName);
-        Graph rightExitGraph = exitGraph.get(rightChildName);
-        Graph newExitGraph =  GraphUtils.disjointUnion(leftExitGraph, rightExitGraph);
-        exitGraph.replace(leftChildName, newExitGraph);
+        Graph leftExitGraph = exitGraphs.get(leftChildName);
+        Graph rightExitGraph = exitGraphs.get(rightChildName);
+        Graph newExitGraph = GraphUtils.disjointUnion(leftExitGraph, rightExitGraph);
+        exitGraphs.replace(leftChildName, newExitGraph);
     }
 
     private void handleChoice(String leftChildName, String rightChildName) {
-        Graph leftEntryGraph = entryGraph.get(leftChildName);
-        Graph rightEntryGraph = entryGraph.get(rightChildName);
-        Graph newEntryGraph =  GraphUtils.join(leftEntryGraph, rightEntryGraph);
-        entryGraph.replace(leftChildName, newEntryGraph);
+        Graph leftEntryGraph = entryGraphs.get(leftChildName);
+        Graph rightEntryGraph = entryGraphs.get(rightChildName);
+        Graph newEntryGraph = GraphUtils.join(leftEntryGraph, rightEntryGraph);
+        entryGraphs.replace(leftChildName, newEntryGraph);
 
-        Graph leftExitGraph = exitGraph.get(leftChildName);
-        Graph rightExitGraph = exitGraph.get(rightChildName);
-        Graph newExitGraph =  GraphUtils.join(leftExitGraph, rightExitGraph);
-        exitGraph.replace(leftChildName, newExitGraph);
+        Graph leftExitGraph = exitGraphs.get(leftChildName);
+        Graph rightExitGraph = exitGraphs.get(rightChildName);
+        Graph newExitGraph = GraphUtils.join(leftExitGraph, rightExitGraph);
+        exitGraphs.replace(leftChildName, newExitGraph);
     }
 
     private void handleSequence(String leftChildName, String rightChildName, Mode mode, WorkspaceEntry we) {
-        Graph leftExitGraph = exitGraph.get(leftChildName);
-        Graph righEntryGraph = entryGraph.get(rightChildName);
-        exitGraph.replace(leftChildName, exitGraph.get(rightChildName));
+        Graph leftExitGraph = exitGraphs.get(leftChildName);
+        Graph righEntryGraph = entryGraphs.get(rightChildName);
+        exitGraphs.replace(leftChildName, exitGraphs.get(rightChildName));
         visualModelDrawingTool.drawVisualObjects(leftExitGraph, righEntryGraph, true, false, mode, we);
     }
 
     private void handleIteration(String leftChildName, int nodeCounter) {
-        Graph leftExitGraph = exitGraph.get(leftChildName);
-        Graph leftExitGraphClone = leftExitGraph.cloneGraph(nodeCounter);
-        Graph newEntryGraph =  GraphUtils.join(leftExitGraph, leftExitGraphClone);
-        entryGraph.replace(leftChildName, newEntryGraph);
+        Graph leftExitGraph = exitGraphs.get(leftChildName);
+        Graph leftExitGraphClone = leftExitGraph.deepClone(nodeCounter);
+        Graph newEntryGraph = GraphUtils.join(leftExitGraph, leftExitGraphClone);
+        entryGraphs.replace(leftChildName, newEntryGraph);
     }
 }

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/tools/PetriDrawingTool.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/tools/PetriDrawingTool.java
@@ -6,9 +6,9 @@ import org.workcraft.dom.visual.Positioning;
 import org.workcraft.exceptions.InvalidConnectionException;
 import org.workcraft.plugins.cflt.graph.Clique;
 import org.workcraft.plugins.cflt.graph.Graph;
+import org.workcraft.plugins.cflt.graph.Vertex;
 import org.workcraft.plugins.cflt.node.NodeCollection;
 import org.workcraft.plugins.cflt.presets.ExpressionParameters.Mode;
-import org.workcraft.plugins.cflt.utils.GraphUtils;
 import org.workcraft.plugins.petri.VisualPetri;
 import org.workcraft.plugins.petri.VisualPlace;
 import org.workcraft.plugins.petri.VisualTransition;
@@ -17,7 +17,6 @@ import org.workcraft.utils.LogUtils;
 import org.workcraft.workspace.WorkspaceEntry;
 
 import static org.workcraft.plugins.cflt.utils.EdgeCliqueCoverUtils.getEdgeCliqueCover;
-import static org.workcraft.plugins.cflt.utils.GraphUtils.getCleanVertexName;
 
 public class PetriDrawingTool implements VisualModelDrawingTool {
     private final Map<String, VisualTransition> transitionNameToVisualTransition = new HashMap<>();
@@ -32,16 +31,16 @@ public class PetriDrawingTool implements VisualModelDrawingTool {
             boolean isSequence, boolean isRoot, Mode mode, WorkspaceEntry we) {
 
         List<Clique> edgeCliqueCover = getEdgeCliqueCover(inputGraph, outputGraph, isSequence, mode);
-        List<String> vertexNames = isSequence
-                ? inputGraph.getVertexNames()
+        List<Vertex> vertices = isSequence
+                ? inputGraph.getVertices()
                 : new ArrayList<>();
-        HashSet<String> inputVertexNames = new HashSet<>(vertexNames);
+        HashSet<Vertex> inputVertices = new HashSet<>(vertices);
 
         VisualPetri visualPetri = WorkspaceUtils.getAs(we, VisualPetri.class);
         if (inputGraph.getIsolatedVertices() != null) {
             this.drawIsolatedVisualObjects(inputGraph, visualPetri, isSequence, isRoot);
         }
-        this.drawRemainingVisualObjects(edgeCliqueCover, visualPetri, inputVertexNames, isRoot);
+        this.drawRemainingVisualObjects(edgeCliqueCover, visualPetri, inputVertices, isRoot);
     }
 
     @Override
@@ -53,24 +52,22 @@ public class PetriDrawingTool implements VisualModelDrawingTool {
     }
 
     private void drawRemainingVisualObjects(List<Clique> edgeCliqueCover, VisualPetri visualPetri,
-            Set<String> inputVertexNames, boolean isRoot) {
-
+            Set<Vertex> inputVertices, boolean isRoot) {
         for (Clique clique : edgeCliqueCover) {
             VisualPlace visualPlace = createVisualPlace(visualPetri, isRoot, Positioning.LEFT);
 
-            for (String vertexName : clique.getVertexNames()) {
-                GraphUtils.GetCleanVertexNameResponse getCleanVertexNameResponse = getCleanVertexName(vertexName);
-                String cleanVertexName = getCleanVertexNameResponse.vertexName();
-                boolean isClone = getCleanVertexNameResponse.isClone();
-                boolean isTransitionPresent = transitionNameToVisualTransition.containsKey(cleanVertexName);
+            for (Vertex vertex : clique.getVertices()) {
+                String name = vertex.name();
+                boolean isClone = vertex.isClone();
+                boolean isTransitionPresent = transitionNameToVisualTransition.containsKey(name);
 
                 VisualTransition visualTransition = isTransitionPresent
-                        ? transitionNameToVisualTransition.get(cleanVertexName)
-                        : createVisualTransition(visualPetri, cleanVertexName);
+                        ? transitionNameToVisualTransition.get(name)
+                        : createVisualTransition(visualPetri, name);
 
-                transitionNameToVisualTransition.put(cleanVertexName, visualTransition);
+                transitionNameToVisualTransition.put(name, visualTransition);
 
-                ConnectionDirection connectionDirection = inputVertexNames.contains(cleanVertexName) || isClone
+                ConnectionDirection connectionDirection = inputVertices.contains(vertex) || isClone
                         ? ConnectionDirection.TRANSITION_TO_PLACE
                         : ConnectionDirection.PLACE_TO_TRANSITION;
 
@@ -80,8 +77,9 @@ public class PetriDrawingTool implements VisualModelDrawingTool {
     }
 
     private void drawIsolatedVisualObjects(Graph inputGraph, VisualPetri visualPetri, boolean isSequence, boolean isRoot) {
-        for (String vertexName : inputGraph.getIsolatedVertices()) {
-            boolean isTransitionNamePresent = transitionNameToVisualTransition.containsKey(vertexName);
+        for (Vertex vertex : inputGraph.getIsolatedVertices()) {
+            String name = vertex.name();
+            boolean isTransitionNamePresent = transitionNameToVisualTransition.containsKey(name);
 
             VisualPlace visualPlace = null;
             if (!isTransitionNamePresent && !isSequence) {
@@ -92,13 +90,13 @@ public class PetriDrawingTool implements VisualModelDrawingTool {
 
             VisualTransition visualTransition = null;
             if (!isTransitionNamePresent && !isSequence) {
-                visualTransition = createVisualTransition(visualPetri, vertexName);
+                visualTransition = createVisualTransition(visualPetri, name);
             } else if (isRoot) {
-                visualTransition = transitionNameToVisualTransition.get(vertexName);
+                visualTransition = transitionNameToVisualTransition.get(name);
             }
 
             if (visualPlace != null && visualTransition != null) {
-                transitionNameToVisualTransition.put(vertexName, visualTransition);
+                transitionNameToVisualTransition.put(name, visualTransition);
                 connectVisualPlaceAndVisualTransition(visualPetri, visualPlace, visualTransition, ConnectionDirection.PLACE_TO_TRANSITION);
             }
         }

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/tools/StgDrawingTool.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/tools/StgDrawingTool.java
@@ -4,10 +4,10 @@ import org.workcraft.dom.visual.Positioning;
 import org.workcraft.exceptions.InvalidConnectionException;
 import org.workcraft.plugins.cflt.graph.Clique;
 import org.workcraft.plugins.cflt.graph.Graph;
+import org.workcraft.plugins.cflt.graph.Vertex;
 import org.workcraft.plugins.cflt.node.NodeCollection;
 import org.workcraft.plugins.cflt.node.NodeDetails;
 import org.workcraft.plugins.cflt.presets.ExpressionParameters.Mode;
-import org.workcraft.plugins.cflt.utils.GraphUtils;
 import org.workcraft.plugins.stg.SignalTransition;
 import org.workcraft.plugins.stg.VisualStg;
 import org.workcraft.plugins.stg.VisualSignalTransition;
@@ -20,7 +20,6 @@ import org.workcraft.workspace.WorkspaceEntry;
 import java.util.*;
 
 import static org.workcraft.plugins.cflt.utils.EdgeCliqueCoverUtils.getEdgeCliqueCover;
-import static org.workcraft.plugins.cflt.utils.GraphUtils.getCleanVertexName;
 
 public class StgDrawingTool implements VisualModelDrawingTool {
     private final Map<String, VisualSignalTransition> transitionNameToVisualTransition = new HashMap<>();
@@ -35,16 +34,16 @@ public class StgDrawingTool implements VisualModelDrawingTool {
             boolean isSequence, boolean isRoot, Mode mode, WorkspaceEntry we) {
 
         List<Clique> edgeCliqueCover = getEdgeCliqueCover(inputGraph, outputGraph, isSequence, mode);
-        List<String> vertexNames = isSequence
-                ? inputGraph.getVertexNames()
+        List<Vertex> vertexNames = isSequence
+                ? inputGraph.getVertices()
                 : new ArrayList<>();
-        HashSet<String> inputVertexNames = new HashSet<>(vertexNames);
+        HashSet<Vertex> inputVertices = new HashSet<>(vertexNames);
 
         VisualStg visualStg = WorkspaceUtils.getAs(we, VisualStg.class);
         if (inputGraph.getIsolatedVertices() != null) {
             this.drawIsolatedVisualObjects(inputGraph, visualStg, isSequence, isRoot);
         }
-        this.drawRemainingVisualObjects(edgeCliqueCover, visualStg, inputVertexNames, isRoot);
+        this.drawRemainingVisualObjects(edgeCliqueCover, visualStg, inputVertices, isRoot);
         makePlacesImplicit(visualStg);
     }
 
@@ -57,23 +56,22 @@ public class StgDrawingTool implements VisualModelDrawingTool {
     }
 
     private void drawRemainingVisualObjects(List<Clique> edgeCliqueCover, VisualStg visualStg,
-            Set<String> inputVertexNames, boolean isRoot) {
+            Set<Vertex> inputVertices, boolean isRoot) {
         for (Clique clique : edgeCliqueCover) {
             VisualStgPlace visualStgPlace = createVisualStgPlace(visualStg, isRoot, Positioning.LEFT);
 
-            for (String vertexName : clique.getVertexNames()) {
-                GraphUtils.GetCleanVertexNameResponse getCleanVertexNameResponse = getCleanVertexName(vertexName);
-                String cleanVertexName = getCleanVertexNameResponse.vertexName();
-                boolean isClone = getCleanVertexNameResponse.isClone();
-                boolean isTransitionPresent = transitionNameToVisualTransition.containsKey(cleanVertexName);
+            for (Vertex vertex : clique.getVertices()) {
+                String name = vertex.name();
+                boolean isClone = vertex.isClone();
+                boolean isTransitionPresent = transitionNameToVisualTransition.containsKey(name);
 
                 VisualSignalTransition visualSignalTransition = isTransitionPresent
-                        ? transitionNameToVisualTransition.get(cleanVertexName)
-                        : createVisualSignalTransition(visualStg, cleanVertexName);
+                        ? transitionNameToVisualTransition.get(name)
+                        : createVisualSignalTransition(visualStg, name);
 
-                transitionNameToVisualTransition.put(cleanVertexName, visualSignalTransition);
+                transitionNameToVisualTransition.put(name, visualSignalTransition);
 
-                ConnectionDirection connectionDirection = inputVertexNames.contains(cleanVertexName) || isClone
+                ConnectionDirection connectionDirection = inputVertices.contains(vertex) || isClone
                         ? ConnectionDirection.TRANSITION_TO_PLACE
                         : ConnectionDirection.PLACE_TO_TRANSITION;
 
@@ -83,8 +81,9 @@ public class StgDrawingTool implements VisualModelDrawingTool {
     }
 
     private void drawIsolatedVisualObjects(Graph inputGraph, VisualStg visualStg, boolean isSequence, boolean isRoot) {
-        for (String vertex : inputGraph.getIsolatedVertices()) {
-            boolean isTransitionNamePresent = transitionNameToVisualTransition.containsKey(vertex);
+        for (Vertex vertex : inputGraph.getIsolatedVertices()) {
+            String name = vertex.name();
+            boolean isTransitionNamePresent = transitionNameToVisualTransition.containsKey(name);
 
             VisualStgPlace visualStgPlace = null;
             if (!isTransitionNamePresent && !isSequence) {
@@ -95,13 +94,13 @@ public class StgDrawingTool implements VisualModelDrawingTool {
 
             VisualSignalTransition visualSignalTransition = null;
             if (!isTransitionNamePresent && !isSequence) {
-                visualSignalTransition = createVisualSignalTransition(visualStg, vertex);
+                visualSignalTransition = createVisualSignalTransition(visualStg, name);
             } else if (isRoot) {
-                visualSignalTransition = transitionNameToVisualTransition.get(vertex);
+                visualSignalTransition = transitionNameToVisualTransition.get(name);
             }
 
             if (visualStgPlace != null && visualSignalTransition != null) {
-                transitionNameToVisualTransition.put(vertex, visualSignalTransition);
+                transitionNameToVisualTransition.put(name, visualSignalTransition);
                 connectVisualPlaceAndVisualSignalTransition(visualStg, visualStgPlace, visualSignalTransition, ConnectionDirection.PLACE_TO_TRANSITION);
             }
         }

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/utils/EdgeCliqueCoverUtils.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/utils/EdgeCliqueCoverUtils.java
@@ -29,6 +29,7 @@ public final class EdgeCliqueCoverUtils {
             ExhaustiveSearch exhaustiveSearch = new ExhaustiveSearch();
             return exhaustiveSearch.getEdgeCliqueCover(initialGraph, optionalEdges);
         }
+
         EdgeCliqueCoverHeuristic heuristic = new EdgeCliqueCoverHeuristic();
         return switch (mode) {
             case FAST_SEQ -> heuristic.getEdgeCliqueCover(initialGraph, optionalEdges, HeuristicType.SEQUENCE);

--- a/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/utils/GraphUtils.java
+++ b/workcraft/CfltPlugin/src/org/workcraft/plugins/cflt/utils/GraphUtils.java
@@ -2,6 +2,7 @@ package org.workcraft.plugins.cflt.utils;
 
 import org.workcraft.plugins.cflt.graph.Edge;
 import org.workcraft.plugins.cflt.graph.Graph;
+import org.workcraft.plugins.cflt.graph.Vertex;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,17 +13,14 @@ public final class GraphUtils {
     private GraphUtils() {
     }
 
-    public static final String SPECIAL_CLONE_CHARACTER = "$";
-
     public static Graph disjointUnion(Graph firstGraph, Graph secondGraph) {
         Stream<Edge> es1 = firstGraph.getEdges().stream();
-        Stream<Edge> es2;
-        es2 = secondGraph.getEdges().stream();
+        Stream<Edge> es2 = secondGraph.getEdges().stream();
         List<Edge> newEdges = Stream.concat(es1, es2).collect(Collectors.toList());
 
-        Stream<String> vs1 = firstGraph.getVertexNames().stream();
-        Stream<String> vs2 = secondGraph.getVertexNames().stream();
-        List<String> newVertices = Stream.concat(vs1, vs2).collect(Collectors.toList());
+        Stream<Vertex> vs1 = firstGraph.getVertices().stream();
+        Stream<Vertex> vs2 = secondGraph.getVertices().stream();
+        List<Vertex> newVertices = Stream.concat(vs1, vs2).collect(Collectors.toList());
 
         return new Graph(newEdges, newVertices);
     }
@@ -30,25 +28,13 @@ public final class GraphUtils {
     public static Graph join(Graph firstGraph, Graph secondGraph) {
         Graph newGraph = disjointUnion(firstGraph, secondGraph);
 
-        firstGraph.getVertexNames()
+        firstGraph.getVertices()
                 .stream()
-                .flatMap(firstVertex -> secondGraph.getVertexNames()
+                .flatMap(firstVertex -> secondGraph.getVertices()
                         .stream()
                         .map(secondVertex -> new Edge(firstVertex, secondVertex)))
                 .forEach(newGraph::addEdge);
 
         return newGraph;
-    }
-
-    public static GetCleanVertexNameResponse getCleanVertexName(String vertexName) {
-        int index = vertexName.indexOf(SPECIAL_CLONE_CHARACTER);
-        boolean isClone = index != -1;
-        String cleanVertexName = isClone
-                ? vertexName.substring(0, index)
-                : vertexName;
-        return new GetCleanVertexNameResponse(cleanVertexName, isClone);
-    }
-
-    public record GetCleanVertexNameResponse(String vertexName, boolean isClone) {
     }
 }

--- a/workcraft/CfltPlugin/test-src/org/workcraft/plugins/cflt/test/EdgeCliqueCoverTests.java
+++ b/workcraft/CfltPlugin/test-src/org/workcraft/plugins/cflt/test/EdgeCliqueCoverTests.java
@@ -11,8 +11,9 @@ import org.workcraft.plugins.cflt.algorithms.EdgeCliqueCoverHeuristic;
 import org.workcraft.plugins.cflt.algorithms.HeuristicType;
 import org.workcraft.plugins.cflt.graph.Clique;
 import org.workcraft.plugins.cflt.graph.Graph;
-import org.workcraft.plugins.cflt.algorithms.ExhaustiveSearch;
+import org.workcraft.plugins.cflt.graph.Vertex;
 import org.workcraft.plugins.cflt.utils.GraphUtils;
+import org.workcraft.plugins.cflt.algorithms.ExhaustiveSearch;
 
 class EdgeCliqueCoverTests {
 
@@ -53,17 +54,17 @@ class EdgeCliqueCoverTests {
     private boolean areCliquesMaxSize(List<Clique> edgeCliqueCover, int requiredSize) {
         return edgeCliqueCover
                 .stream()
-                .allMatch(clique -> clique.getVertexNames().size() == requiredSize);
+                .allMatch(clique -> clique.getVertices().size() == requiredSize);
     }
 
     private boolean doesCover(List<Clique> edgeCliqueCover, Graph graph) {
-        Set<String> vertexNames = edgeCliqueCover
+        Set<Vertex> vertices = edgeCliqueCover
                 .stream()
-                .flatMap(clique -> clique.getVertexNames()
+                .flatMap(clique -> clique.getVertices()
                         .stream())
                 .collect(Collectors.toSet());
 
-        return vertexNames.containsAll(graph.getVertexNames());
+        return vertices.containsAll(graph.getVertices());
     }
 
     /**
@@ -72,26 +73,25 @@ class EdgeCliqueCoverTests {
      */
     private Graph getGraph() {
         Graph graph = new Graph();
-        graph.addVertexName("A");
-        graph.addVertexName("B");
+        graph.addVertex(new Vertex("A"));
+        graph.addVertex(new Vertex("B"));
 
         Graph secondGraph = new Graph();
-        secondGraph.addVertexName("C");
-        secondGraph.addVertexName("D");
+        secondGraph.addVertex(new Vertex("C"));
+        secondGraph.addVertex(new Vertex("D"));
 
         Graph thirdGraph = new Graph();
-        thirdGraph.addVertexName("E");
-        thirdGraph.addVertexName("F");
+        thirdGraph.addVertex(new Vertex("E"));
+        thirdGraph.addVertex(new Vertex("F"));
 
         Graph fourthGraph = new Graph();
-        fourthGraph.addVertexName("G");
-        fourthGraph.addVertexName("H");
+        fourthGraph.addVertex(new Vertex("G"));
+        fourthGraph.addVertex(new Vertex("H"));
 
-        Graph finalGraph = GraphUtils.join(graph, secondGraph);
-        finalGraph = GraphUtils.join(finalGraph, thirdGraph);
-        finalGraph = GraphUtils.join(finalGraph, fourthGraph);
+        Graph result = GraphUtils.join(graph, secondGraph);
+        result = GraphUtils.join(result, thirdGraph);
+        result = GraphUtils.join(result, fourthGraph);
 
-        return finalGraph;
+        return result;
     }
-
 }

--- a/workcraft/CfltPlugin/test-src/org/workcraft/plugins/cflt/test/EdgeTests.java
+++ b/workcraft/CfltPlugin/test-src/org/workcraft/plugins/cflt/test/EdgeTests.java
@@ -1,0 +1,41 @@
+package org.workcraft.plugins.cflt.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.workcraft.plugins.cflt.graph.Edge;
+import org.workcraft.plugins.cflt.graph.Vertex;
+
+class EdgeTests {
+
+    @Test
+    void edgesWithSameVertiesAreEqual() {
+        Vertex a = new Vertex("A");
+        Vertex b = new Vertex("B");
+
+        Edge e1 = new Edge(a, b);
+        Edge e2 = new Edge(b, a);
+
+        Assertions.assertEquals(e1, e2);
+        Assertions.assertEquals(e1, e1);
+    }
+
+    @Test
+    void edgesWithDifferentVerticesAreNotEqual() {
+        Vertex a = new Vertex("A");
+        Vertex b = new Vertex("B");
+        Vertex c = new Vertex("C");
+
+        Assertions.assertNotEquals(new Edge(a, b), new Edge(a, c));
+    }
+
+    @Test
+    void reversedEdgesHaveSameHashCode() {
+        Vertex a = new Vertex("A");
+        Vertex b = new Vertex("B");
+
+        Assertions.assertEquals(
+            new Edge(a, b).hashCode(),
+            new Edge(b, a).hashCode()
+        );
+    }
+}

--- a/workcraft/CfltPlugin/test-src/org/workcraft/plugins/cflt/test/GraphTests.java
+++ b/workcraft/CfltPlugin/test-src/org/workcraft/plugins/cflt/test/GraphTests.java
@@ -1,0 +1,86 @@
+package org.workcraft.plugins.cflt.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.workcraft.plugins.cflt.graph.Edge;
+import org.workcraft.plugins.cflt.graph.Graph;
+import org.workcraft.plugins.cflt.graph.Vertex;
+
+import java.util.List;
+
+class GraphTests {
+
+    @Test
+    void addVertexAddsVertex() {
+        Graph graph = new Graph();
+
+        Vertex vertex = new Vertex("A");
+        graph.addVertex(vertex);
+
+        Assertions.assertEquals(List.of(vertex), graph.getVertices());
+    }
+
+    @Test
+    void addEdgeAddsEdge() {
+        Graph graph = new Graph();
+
+        Vertex a = new Vertex("A");
+        Vertex b = new Vertex("B");
+
+        graph.addVertex(a);
+        graph.addVertex(b);
+
+        Edge edge = new Edge(a, b);
+
+        graph.addEdge(edge);
+
+        Assertions.assertEquals(List.of(edge), graph.getEdges());
+    }
+
+    @Test
+    void cloneGraphCreatesRenamedCopy() {
+        Graph graph = new Graph();
+
+        Vertex a = new Vertex("A");
+        Vertex b = new Vertex("B");
+
+        graph.addVertex(a);
+        graph.addVertex(b);
+
+        graph.addEdge(new Edge(a, b));
+
+        Graph clone = graph.deepClone(1);
+
+        Vertex aClone = new Vertex("A", true, 1);
+        Vertex bClone = new Vertex("B", true, 1);
+
+        Assertions.assertEquals(
+                List.of(aClone, bClone),
+                clone.getVertices()
+        );
+
+        Assertions.assertEquals(
+                List.of(new Edge(aClone, bClone)),
+                clone.getEdges()
+        );
+    }
+
+    @Test
+    void getIsolatedVerticesReturnsVerticesWithoutEdges() {
+        Graph graph = new Graph();
+
+        Vertex a = new Vertex("A");
+        Vertex b = new Vertex("B");
+        Vertex c = new Vertex("C");
+
+        graph.addVertex(a);
+        graph.addVertex(b);
+        graph.addVertex(c);
+
+        graph.addEdge(new Edge(a, b));
+
+        List<Vertex> isolated = graph.getIsolatedVertices();
+
+        Assertions.assertEquals(List.of(c), isolated);
+    }
+}


### PR DESCRIPTION
Replace raw string vertices with a Vertex record.

This removes the need for hacky string-based logic and makes vertex handling more explicit.

In the future, a field containing a collection of all neighbours could be added to the record and initialised when graphs are built, removing the need for later initialisation.